### PR TITLE
fix Revolut importer, add balance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 tags
+*.code-workspace
 
 # Package files
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 tags
+.vscode/*
 *.code-workspace
 
 # Package files

--- a/README.rst
+++ b/README.rst
@@ -232,3 +232,17 @@ Create a file called blockchain.yaml in your import location (e.g. downloads fol
 
   from tariochbctools.importers.blockchain import importer as bcimp
   CONFIG = [bcimp.Importer()]
+
+Syncing a fork
+--------------
+
+Details: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/syncing-a-fork
+
+::
+
+  git remote add upstream https://github.com/tarioch/beancounttools.git
+  git remote -v
+  git fetch upstream
+  git checkout master
+  git merge upstream/master
+  git push


### PR DESCRIPTION
@tarioch I tried to use the Revolut importer, but it crashed. After debugging I made the following fixes:
- column "Notes" was not to be found in my files (even the older ones) and the loader crashed, I removed Notes
- there was a quote in amount 1'978 and it crashed, removed the quote
- added one balance directive for the most recent transaction

I also stored a quick guide in Readme on how to merge a fork for self reference.