### PR TITLE
Revolut Importer: Change delimiter from semicolon to comma

### DIFF
--- a/src/tariochbctools/importers/revolut/importer.py
+++ b/src/tariochbctools/importers/revolut/importer.py
@@ -33,7 +33,7 @@ class Importer(identifier.IdentifyMixin, importer.ImporterProtocol):
         has_balance = False
 
         with StringIO(file.contents()) as csvfile:
-            reader = csv.DictReader(csvfile, ['Date', 'Reference', 'PaidOut', 'PaidIn', 'ExchangeOut', 'ExchangeIn', 'Balance', 'Category'], delimiter=';', skipinitialspace=True)
+            reader = csv.DictReader(csvfile, ['Date', 'Reference', 'PaidOut', 'PaidIn', 'ExchangeOut', 'ExchangeIn', 'Balance', 'Category'], delimiter=',', skipinitialspace=True)
             next(reader)
             for row in reader:
                 metakv = {


### PR DESCRIPTION
I don't know if this has changed, but Revolut statements are not having a semicolon for me.
In the CSV generated from the app, I get it in this format:

```
Completed Date , Description , Paid Out (CHF) , Paid In (CHF) , Exchange Out, Exchange In, Balance (CHF), Category, Notes
"Aug 1, 2021" , Coop Pronto Schaffhausen Bahnhof  , 9.10 ,  ,  ,  , 1.47, Transport, 
"Jul 29, 2021" , To some person  , 10.00 ,  ,  ,  , 10.57, Transfers, 
"Jul 29, 2021" , Bought CHF with EUR FX Rate Fr 1 = €0.9270 ,  , 20.00 ,  EUR 18.55 ,  , 20.57, General,
```

If the importer is ran with a semicolon delimiter, I get the following error:

```
ERROR:root:Importer tariochbctools.importers.revolut.importer.ImporterAssets:Revolut:CHF.extract() raised an unexpected error: 'NoneType' object has no attribute 'strip'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/beancount/ingest/extract.py", line 182, in extract
    new_entries = extract_from_file(
  File "/usr/local/lib/python3.9/site-packages/beancount/ingest/extract.py", line 67, in extract_from_file
    new_entries = importer.extract(file, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/tariochbctools/importers/revolut/importer.py", line 40, in extract
    'category': row['Category'].strip(),
AttributeError: 'NoneType' object has no attribute 'strip'
;; -*- mode: beancount -*-
```