### PR TITLE
Truelayer endpoints

### DIFF
--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -25,6 +25,7 @@ class Importer(importer.ImporterProtocol):
         baseAccount = config["baseAccount"]
         clientId = config["client_id"]
         clientSecret = config["client_secret"]
+        endpoint = config.get("endpoint", "accounts")  # or "cards"
         refreshToken = config["refresh_token"]
         sandbox = clientId.startswith("sandbox")
 
@@ -47,12 +48,12 @@ class Importer(importer.ImporterProtocol):
         headers = {"Authorization": "Bearer " + accessToken}
 
         entries = []
-        r = requests.get(f"https://api.{domain}/data/v1/accounts", headers=headers)
+        r = requests.get(f"https://api.{domain}/data/v1/{endpoint}", headers=headers)
         for account in r.json()["results"]:
             accountId = account["account_id"]
             accountCcy = account["currency"]
             r = requests.get(
-                f"https://api.{domain}/data/v1/accounts/{accountId}/transactions",
+                f"https://api.{domain}/data/v1/{endpoint}/{accountId}/transactions",
                 headers=headers,
             )
             transactions = sorted(r.json()["results"], key=lambda trx: trx["timestamp"])

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -1,7 +1,7 @@
-import yaml
-import dateutil.parser
 from datetime import timedelta
 from os import path
+import yaml
+import dateutil.parser
 import requests
 
 from beancount.ingest import importer
@@ -14,75 +14,97 @@ class Importer(importer.ImporterProtocol):
     """An importer for Truelayer API (e.g. for Revolut)."""
 
     def identify(self, file):
-        return 'truelayer.yaml' == path.basename(file.name)
+        return "truelayer.yaml" == path.basename(file.name)
 
     def file_account(self, file):
-        return ''
+        return ""
 
     def extract(self, file, existing_entries):
-        with open(file.name, 'r') as f:
+        with open(file.name, "r") as f:
             config = yaml.safe_load(f)
-        baseAccount = config['baseAccount']
-        clientId = config['client_id']
-        clientSecret = config['client_secret']
-        refreshToken = config['refresh_token']
+        baseAccount = config["baseAccount"]
+        clientId = config["client_id"]
+        clientSecret = config["client_secret"]
+        refreshToken = config["refresh_token"]
 
-        r = requests.post('https://auth.truelayer.com/connect/token', data={
-            "grant_type": "refresh_token",
-            "client_id": clientId,
-            "client_secret": clientSecret,
-            "refresh_token": refreshToken,
-        })
+        r = requests.post(
+            "https://auth.truelayer.com/connect/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": clientId,
+                "client_secret": clientSecret,
+                "refresh_token": refreshToken,
+            },
+        )
         tokens = r.json()
-        accessToken = tokens['access_token']
-        headers = {'Authorization': 'Bearer ' + accessToken}
+        accessToken = tokens["access_token"]
+        headers = {"Authorization": "Bearer " + accessToken}
 
         entries = []
-        r = requests.get('https://api.truelayer.com/data/v1/accounts', headers=headers)
-        for account in r.json()['results']:
-            accountId = account['account_id']
-            accountCcy = account['currency']
-            r = requests.get(f'https://api.truelayer.com/data/v1/accounts/{accountId}/transactions', headers=headers)
-            transactions = sorted(r.json()['results'], key=lambda trx: trx['timestamp'])
+        r = requests.get("https://api.truelayer.com/data/v1/accounts", headers=headers)
+        for account in r.json()["results"]:
+            accountId = account["account_id"]
+            accountCcy = account["currency"]
+            r = requests.get(
+                f"https://api.truelayer.com/data/v1/accounts/{accountId}/transactions",
+                headers=headers,
+            )
+            transactions = sorted(r.json()["results"], key=lambda trx: trx["timestamp"])
             for trx in transactions:
                 metakv = {
-                    'tlref': trx['meta']['provider_id'],
+                    "tlref": trx["meta"]["provider_id"],
                 }
-                if trx['transaction_classification']:
-                    metakv['category'] = trx['transaction_classification'][0]
-                meta = data.new_metadata('', 0, metakv)
-                trxDate = dateutil.parser.parse(trx['timestamp']).date()
+                if trx["transaction_classification"]:
+                    metakv["category"] = trx["transaction_classification"][0]
+                meta = data.new_metadata("", 0, metakv)
+                trxDate = dateutil.parser.parse(trx["timestamp"]).date()
                 account = baseAccount + accountCcy
                 entry = data.Transaction(
                     meta,
                     trxDate,
-                    '*',
-                    '',
-                    trx['description'],
+                    "*",
+                    "",
+                    trx["description"],
                     data.EMPTY_SET,
                     data.EMPTY_SET,
                     [
-                        data.Posting(account, amount.Amount(D(str(trx['amount'])), trx['currency']), None, None, None, None),
-                    ]
+                        data.Posting(
+                            account,
+                            amount.Amount(D(str(trx["amount"])), trx["currency"]),
+                            None,
+                            None,
+                            None,
+                            None,
+                        ),
+                    ],
                 )
                 entries.append(entry)
 
-                if trx['transaction_id'] == transactions[-1]['transaction_id']:
+                if trx["transaction_id"] == transactions[-1]["transaction_id"]:
                     balDate = trxDate + timedelta(days=1)
                     metakv = {}
                     if existing_entries is not None:
                         for exEntry in existing_entries:
-                            if isinstance(exEntry, data.Balance) and exEntry.date == balDate and exEntry.account == account:
-                                metakv['__duplicate__'] = True
+                            if (
+                                isinstance(exEntry, data.Balance)
+                                and exEntry.date == balDate
+                                and exEntry.account == account
+                            ):
+                                metakv["__duplicate__"] = True
 
-                    meta = data.new_metadata('', 0, metakv)
-                    entries.append(data.Balance(
-                        meta,
-                        balDate,
-                        account,
-                        amount.Amount(D(str(trx['running_balance']['amount'])), trx['running_balance']['currency']),
-                        None,
-                        None,
-                    ))
+                    meta = data.new_metadata("", 0, metakv)
+                    entries.append(
+                        data.Balance(
+                            meta,
+                            balDate,
+                            account,
+                            amount.Amount(
+                                D(str(trx["running_balance"]["amount"])),
+                                trx["running_balance"]["currency"],
+                            ),
+                            None,
+                            None,
+                        )
+                    )
 
         return entries

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -26,9 +26,15 @@ class Importer(importer.ImporterProtocol):
         clientId = config["client_id"]
         clientSecret = config["client_secret"]
         refreshToken = config["refresh_token"]
+        sandbox = clientId.startswith("sandbox")
+
+        if sandbox:
+            domain = "truelayer-sandbox.com"
+        else:
+            domain = "truelayer.com"
 
         r = requests.post(
-            "https://auth.truelayer.com/connect/token",
+            f"https://auth.{domain}/connect/token",
             data={
                 "grant_type": "refresh_token",
                 "client_id": clientId,
@@ -41,21 +47,26 @@ class Importer(importer.ImporterProtocol):
         headers = {"Authorization": "Bearer " + accessToken}
 
         entries = []
-        r = requests.get("https://api.truelayer.com/data/v1/accounts", headers=headers)
+        r = requests.get(f"https://api.{domain}/data/v1/accounts", headers=headers)
         for account in r.json()["results"]:
             accountId = account["account_id"]
             accountCcy = account["currency"]
             r = requests.get(
-                f"https://api.truelayer.com/data/v1/accounts/{accountId}/transactions",
+                f"https://api.{domain}/data/v1/accounts/{accountId}/transactions",
                 headers=headers,
             )
             transactions = sorted(r.json()["results"], key=lambda trx: trx["timestamp"])
+
             for trx in transactions:
-                metakv = {
-                    "tlref": trx["meta"]["provider_id"],
-                }
+                metakv = {}
+
+                # sandbox Mock bank doesn't have a provider_id
+                if "meta" in trx and "provider_id" in trx["meta"]:
+                    metakv["tlref"] = trx["meta"]["provider_id"]
+
                 if trx["transaction_classification"]:
                     metakv["category"] = trx["transaction_classification"][0]
+
                 meta = data.new_metadata("", 0, metakv)
                 trxDate = dateutil.parser.parse(trx["timestamp"]).date()
                 account = baseAccount + accountCcy

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -104,18 +104,21 @@ class Importer(importer.ImporterProtocol):
                                 metakv["__duplicate__"] = True
 
                     meta = data.new_metadata("", 0, metakv)
-                    entries.append(
-                        data.Balance(
-                            meta,
-                            balDate,
-                            account,
-                            amount.Amount(
-                                D(str(trx["running_balance"]["amount"])),
-                                trx["running_balance"]["currency"],
-                            ),
-                            None,
-                            None,
+
+                    # Only if the 'balance' permission is present
+                    if "running_balance" in trx:
+                        entries.append(
+                            data.Balance(
+                                meta,
+                                balDate,
+                                account,
+                                amount.Amount(
+                                    D(str(trx["running_balance"]["amount"])),
+                                    trx["running_balance"]["currency"],
+                                ),
+                                None,
+                                None,
+                            )
                         )
-                    )
 
         return entries


### PR DESCRIPTION
(First commit applies 'black' code formatter. It is whitespace-only.)
(Second commit adds sandbox support - by checking the client_id prefix.)

Lets the user switch between 'accounts' (the default) and 'cards' endpoints.

In truelayer.yaml:

```yaml
endpoint: cards
```

We could support *both* APIs but this seems good enough for now.

For me this fixes Amex UK tx retrieval (`card` endpoint only).