### PR TITLE
Truelayer cards

### DIFF
--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -103,18 +103,21 @@ class Importer(importer.ImporterProtocol):
                                 metakv["__duplicate__"] = True
 
                     meta = data.new_metadata("", 0, metakv)
-                    entries.append(
-                        data.Balance(
-                            meta,
-                            balDate,
-                            account,
-                            amount.Amount(
-                                D(str(trx["running_balance"]["amount"])),
-                                trx["running_balance"]["currency"],
-                            ),
-                            None,
-                            None,
+
+                    # Only if the 'balance' permission is present
+                    if "running_balance" in trx:
+                        entries.append(
+                            data.Balance(
+                                meta,
+                                balDate,
+                                account,
+                                amount.Amount(
+                                    D(str(trx["running_balance"]["amount"])),
+                                    trx["running_balance"]["currency"],
+                                ),
+                                None,
+                                None,
+                            )
                         )
-                    )
 
         return entries

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -12,33 +12,45 @@ from beancount.ingest import importer
 class Importer(importer.ImporterProtocol):
     """An importer for Truelayer API (e.g. for Revolut)."""
 
+    def __init__(self):
+        self.config = None
+        self.baseAccount = None
+        self.clientId = None
+        self.clientSecret = None
+        self.refreshToken = None
+        self.sandbox = None
+        self.existing_entries = None
+        self.domain = "truelayer.com"
+
+    def _configure(self, file, existing_entries):
+        with open(file.name, "r") as f:
+            self.config = yaml.safe_load(f)
+        self.baseAccount = self.config["baseAccount"]
+        self.clientId = self.config["client_id"]
+        self.clientSecret = self.config["client_secret"]
+        self.refreshToken = self.config["refresh_token"]
+        self.sandbox = self.clientId.startswith("sandbox")
+        self.existing_entries = existing_entries
+
+        if self.sandbox:
+            self.domain = "truelayer-sandbox.com"
+
     def identify(self, file):
         return "truelayer.yaml" == path.basename(file.name)
 
     def file_account(self, file):
         return ""
 
-    def extract(self, file, existing_entries):
-        with open(file.name, "r") as f:
-            config = yaml.safe_load(f)
-        baseAccount = config["baseAccount"]
-        clientId = config["client_id"]
-        clientSecret = config["client_secret"]
-        refreshToken = config["refresh_token"]
-        sandbox = clientId.startswith("sandbox")
-
-        if sandbox:
-            domain = "truelayer-sandbox.com"
-        else:
-            domain = "truelayer.com"
+    def extract(self, file, existing_entries=None):
+        self._configure(file, existing_entries)
 
         r = requests.post(
-            f"https://auth.{domain}/connect/token",
+            f"https://auth.{self.domain}/connect/token",
             data={
                 "grant_type": "refresh_token",
-                "client_id": clientId,
-                "client_secret": clientSecret,
-                "refresh_token": refreshToken,
+                "client_id": self.clientId,
+                "client_secret": self.clientSecret,
+                "refresh_token": self.refreshToken,
             },
         )
         tokens = r.json()
@@ -46,78 +58,90 @@ class Importer(importer.ImporterProtocol):
         headers = {"Authorization": "Bearer " + accessToken}
 
         entries = []
-        r = requests.get(f"https://api.{domain}/data/v1/accounts", headers=headers)
+        entries.extend(self._extract_endpoint_transactions("accounts", headers))
+
+        return entries
+
+    def _extract_endpoint_transactions(self, endpoint, headers):
+        entries = []
+        r = requests.get(f"https://api.{self.domain}/data/v1/{endpoint}", headers=headers)
+
         for account in r.json()["results"]:
             accountId = account["account_id"]
             accountCcy = account["currency"]
             r = requests.get(
-                f"https://api.{domain}/data/v1/accounts/{accountId}/transactions",
+                f"https://api.{self.domain}/data/v1/{endpoint}/{accountId}/transactions",
                 headers=headers,
             )
             transactions = sorted(r.json()["results"], key=lambda trx: trx["timestamp"])
 
             for trx in transactions:
-                metakv = {}
+                entries.extend(self._extract_transaction(trx, accountCcy, transactions))
 
-                # sandbox Mock bank doesn't have a provider_id
-                if "meta" in trx and "provider_id" in trx["meta"]:
-                    metakv["tlref"] = trx["meta"]["provider_id"]
+        return entries
 
-                if trx["transaction_classification"]:
-                    metakv["category"] = trx["transaction_classification"][0]
+    def _extract_transaction(self, trx, accountCcy, transactions):
+        entries = []
+        metakv = {}
+        # sandbox Mock bank doesn't have a provider_id
+        if "meta" in trx and "provider_id" in trx["meta"]:
+            metakv["tlref"] = trx["meta"]["provider_id"]
 
-                meta = data.new_metadata("", 0, metakv)
-                trxDate = dateutil.parser.parse(trx["timestamp"]).date()
-                account = baseAccount + accountCcy
-                entry = data.Transaction(
-                    meta,
-                    trxDate,
-                    "*",
-                    "",
-                    trx["description"],
-                    data.EMPTY_SET,
-                    data.EMPTY_SET,
-                    [
-                        data.Posting(
-                            account,
-                            amount.Amount(D(str(trx["amount"])), trx["currency"]),
-                            None,
-                            None,
-                            None,
-                            None,
+        if trx["transaction_classification"]:
+            metakv["category"] = trx["transaction_classification"][0]
+
+        meta = data.new_metadata("", 0, metakv)
+        trxDate = dateutil.parser.parse(trx["timestamp"]).date()
+        account = self.baseAccount + accountCcy
+        entry = data.Transaction(
+            meta,
+            trxDate,
+            "*",
+            "",
+            trx["description"],
+            data.EMPTY_SET,
+            data.EMPTY_SET,
+            [
+                data.Posting(
+                    account,
+                    amount.Amount(D(str(trx["amount"])), trx["currency"]),
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        entries.append(entry)
+
+        if trx["transaction_id"] == transactions[-1]["transaction_id"]:
+            balDate = trxDate + timedelta(days=1)
+            metakv = {}
+            if self.existing_entries is not None:
+                for exEntry in self.existing_entries:
+                    if (
+                        isinstance(exEntry, data.Balance)
+                        and exEntry.date == balDate
+                        and exEntry.account == account
+                    ):
+                        metakv["__duplicate__"] = True
+
+            meta = data.new_metadata("", 0, metakv)
+
+            # Only if the 'balance' permission is present
+            if "running_balance" in trx:
+                entries.append(
+                    data.Balance(
+                        meta,
+                        balDate,
+                        account,
+                        amount.Amount(
+                            D(str(trx["running_balance"]["amount"])),
+                            trx["running_balance"]["currency"],
                         ),
-                    ],
+                        None,
+                        None,
+                    )
                 )
-                entries.append(entry)
-
-                if trx["transaction_id"] == transactions[-1]["transaction_id"]:
-                    balDate = trxDate + timedelta(days=1)
-                    metakv = {}
-                    if existing_entries is not None:
-                        for exEntry in existing_entries:
-                            if (
-                                isinstance(exEntry, data.Balance)
-                                and exEntry.date == balDate
-                                and exEntry.account == account
-                            ):
-                                metakv["__duplicate__"] = True
-
-                    meta = data.new_metadata("", 0, metakv)
-
-                    # Only if the 'balance' permission is present
-                    if "running_balance" in trx:
-                        entries.append(
-                            data.Balance(
-                                meta,
-                                balDate,
-                                account,
-                                amount.Amount(
-                                    D(str(trx["running_balance"]["amount"])),
-                                    trx["running_balance"]["currency"],
-                                ),
-                                None,
-                                None,
-                            )
-                        )
 
         return entries

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -1,7 +1,7 @@
 import json
-import pytest
 
-from beancount.core.amount import Amount as A, Decimal as D
+import pytest
+from beancount.core.amount import Decimal as D
 
 from tariochbctools.importers.truelayer import importer as tlimp
 
@@ -36,12 +36,14 @@ TEST_TRX = b"""
 }
 """
 
+
 @pytest.fixture(name="importer")
 def truelayer_importer_fixture():
     importer = tlimp.Importer()
     # TODO: _configure the importer
     importer.baseAccount = "Liabilities:Other"
     yield importer
+
 
 @pytest.fixture(name="tmp_config")
 def tmp_config_fixture(tmp_path):
@@ -60,12 +62,16 @@ def test_identify(importer, tmp_config):
 
 
 def test_extract_transaction_simple(importer, tmp_trx):
-    entries = importer._extract_transaction(tmp_trx, "GBP", [tmp_trx], invert_sign=False)
+    entries = importer._extract_transaction(
+        tmp_trx, "GBP", [tmp_trx], invert_sign=False
+    )
     assert entries[0].postings[0].units.number == D(str(tmp_trx["amount"]))
 
 
 def test_extract_transaction_with_balance(importer, tmp_trx):
-    entries = importer._extract_transaction(tmp_trx, "GBP", [tmp_trx], invert_sign=False)
+    entries = importer._extract_transaction(
+        tmp_trx, "GBP", [tmp_trx], invert_sign=False
+    )
     # one entry, one balance
     assert len(entries) == 2
     assert entries[1].amount.number == D(str(tmp_trx["running_balance"]["amount"]))

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -1,0 +1,77 @@
+import json
+import pytest
+
+from beancount.core.amount import Amount as A, Decimal as D
+
+from tariochbctools.importers.truelayer import importer as tlimp
+
+# pylint: disable=protected-access
+
+TEST_CONFIG = b"""
+    baseAccount: Liabilities:Other
+    client_id: sandbox-random
+    client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
+    refresh_token: 98D124C0E677865CB2F7D9DE91DC394CEED31DA3469C681B41FB7831F2F9B089
+    access_token: eyJhbGciOiJSUzI1NiIsImtpZsomethingSomethingsomethingDarkSideOEJBNk
+"""
+
+# Example from the truelayer Mock bank
+TEST_TRX = b"""
+{
+  "timestamp": "2021-06-14T00:00:00Z",
+  "description": "MT SECURETRADE LIM",
+  "transaction_type": "CREDIT",
+  "transaction_category": "PURCHASE",
+  "transaction_classification": [],
+  "amount": -20.5,
+  "currency": "GBP",
+  "transaction_id": "81cd222c77f49eb11b72a82478a07dbd",
+  "provider_transaction_id": "6906e4ecbf4a9775e3",
+  "normalised_provider_transaction_id": "txn-4912996e337e5b5f3",
+  "running_balance": {
+    "currency": "GBP",
+    "amount": 332.94
+  },
+  "meta": {"provider_transaction_category": "DEB"}
+}
+"""
+
+@pytest.fixture(name="importer")
+def truelayer_importer_fixture():
+    importer = tlimp.Importer()
+    # TODO: _configure the importer
+    importer.baseAccount = "Liabilities:Other"
+    yield importer
+
+@pytest.fixture(name="tmp_config")
+def tmp_config_fixture(tmp_path):
+    config = tmp_path / "truelayer.yaml"
+    config.write_bytes(TEST_CONFIG)
+    yield config
+
+
+@pytest.fixture(name="tmp_trx")
+def tmp_trx_fixture():
+    yield json.loads(TEST_TRX)
+
+
+def test_identify(importer, tmp_config):
+    assert importer.identify(tmp_config)
+
+
+def test_extract_transaction_simple(importer, tmp_trx):
+    entries = importer._extract_transaction(tmp_trx, "GBP", [tmp_trx], invert_sign=False)
+    assert entries[0].postings[0].units.number == D(str(tmp_trx["amount"]))
+
+
+def test_extract_transaction_with_balance(importer, tmp_trx):
+    entries = importer._extract_transaction(tmp_trx, "GBP", [tmp_trx], invert_sign=False)
+    # one entry, one balance
+    assert len(entries) == 2
+    assert entries[1].amount.number == D(str(tmp_trx["running_balance"]["amount"]))
+
+
+def test_extract_transaction_invert_sign(importer, tmp_trx):
+    """Show that sign inversion works"""
+    entries = importer._extract_transaction(tmp_trx, "GBP", [tmp_trx], invert_sign=True)
+    assert entries[0].postings[0].units.number == -D(str(tmp_trx["amount"]))


### PR DESCRIPTION
(First commit applies 'black' code formatter. It is whitespace-only.)
(Second commit adds sandbox support - by checking the client_id prefix.)

Extracts transactions from both `accounts`  and `cards` endpoints.

It also:
* Refactors `extract()`.
* Logs a warning when either request fails.
* Inverts the sign of `cards` transactions.

There are no new configurations options.

Limitations:
* if both `accounts` and `cards` exist this will post all transactions to the (single) configured account
* as on master, this doesn't try to handle multiple accounts (or cards)
