### PR TITLE
Truelayer multiple accounts

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -78,10 +78,21 @@ Create a file called truelayer.yaml in your import location (e.g. download folde
 
 .. code-block:: yaml
 
-  baseAccount: <Assets:MyBank:>
+  baseAccount: <Assets:MyBank>
   client_id: <CLIENT ID>
   client_secret: <CLIENT SECRET>
   refresh_token: <REFRESH TOKEN>
+
+The configuration may include a mapping from TrueLayer account IDs to beancount
+accounts. e.g.:
+
+.. code-block:: yaml
+
+  accounts:
+    1aacb3110398ec5a2334fb0ffc2fface: Assets:Revolut:GBP
+    ec34db160c61d468dc1cedde8bedb1f1: Liabilities:Visa
+
+If it is present, transactions for *only these accounts* will be imported.
 
 
 Nordigen

--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -78,13 +78,13 @@ Create a file called truelayer.yaml in your import location (e.g. download folde
 
 .. code-block:: yaml
 
-  baseAccount: <Assets:MyBank>
+  account: <Assets:MyBank>
   client_id: <CLIENT ID>
   client_secret: <CLIENT SECRET>
   refresh_token: <REFRESH TOKEN>
 
-The configuration may include a mapping from TrueLayer account IDs to beancount
-accounts. e.g.:
+Instead of a single ``account``, the configuration may include a *mapping* from
+TrueLayer account IDs to beancount accounts. e.g.:
 
 .. code-block:: yaml
 

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -96,7 +96,6 @@ class Importer(importer.ImporterProtocol):
 
         for account in r.json()["results"]:
             accountId = account["account_id"]
-            accountCcy = account["currency"]
             r = requests.get(
                 f"https://api.{self.domain}/data/v1/{endpoint}/{accountId}/transactions",
                 headers=headers,
@@ -105,14 +104,12 @@ class Importer(importer.ImporterProtocol):
 
             for trx in transactions:
                 entries.extend(
-                    self._extract_transaction(
-                        trx, accountCcy, transactions, invert_sign
-                    )
+                    self._extract_transaction(trx, transactions, invert_sign)
                 )
 
         return entries
 
-    def _extract_transaction(self, trx, accountCcy, transactions, invert_sign):
+    def _extract_transaction(self, trx, transactions, invert_sign):
         entries = []
         metakv = {}
 
@@ -133,7 +130,7 @@ class Importer(importer.ImporterProtocol):
 
         meta = data.new_metadata("", 0, metakv)
         trxDate = dateutil.parser.parse(trx["timestamp"]).date()
-        account = self.baseAccount + accountCcy
+        account = self.baseAccount
 
         tx_amount = D(str(trx["amount"]))
         # avoid pylint invalid-unary-operand-type

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -10,7 +10,7 @@ from tariochbctools.importers.truelayer import importer as tlimp
 # pylint: disable=protected-access
 
 TEST_CONFIG = b"""
-    baseAccount: Liabilities:Other
+    account: DefaultAccount
     client_id: sandbox-random
     client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
     refresh_token: 98D124C0E677865CB2F7D9DE91DC394CEED31DA3469C681B41FB7831F2F9B089
@@ -189,7 +189,7 @@ def test_get_account_for_account_id_returns_none(importer):
 
 def test_accounts_config_is_optional(importer_factory):
     TEST_CONFIG_WITHOUT_ACCOUNTS = b"""
-        baseAccount: Liabilities:Other
+        account: DefaultAccount
         client_id: sandbox-random
         client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
         refresh_token: 98D124C0E677865CB2F7D9DE91DC394CEED31DA3469C681B41FB7831F2F9B089
@@ -197,6 +197,4 @@ def test_accounts_config_is_optional(importer_factory):
     """
 
     importer = importer_factory(TEST_CONFIG_WITHOUT_ACCOUNTS)
-    assert (
-        importer._get_account_for_account_id("any-account-id-1") is importer.baseAccount
-    )
+    assert importer._get_account_for_account_id("any-account-id-1") == "DefaultAccount"

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from beancount.core.amount import Decimal as D
+from beancount.ingest import cache
 
 from tariochbctools.importers.truelayer import importer as tlimp
 
@@ -62,19 +63,18 @@ TEST_TRX_WITHOUT_IDS = b"""
 """
 
 
-@pytest.fixture(name="importer")
-def truelayer_importer_fixture():
-    importer = tlimp.Importer()
-    # TODO: _configure the importer
-    importer.baseAccount = "Liabilities:Other"
-    yield importer
-
-
 @pytest.fixture(name="tmp_config")
 def tmp_config_fixture(tmp_path):
     config = tmp_path / "truelayer.yaml"
     config.write_bytes(TEST_CONFIG)
-    yield config
+    yield cache.get_file(config)  # a FileMemo, not a Path
+
+
+@pytest.fixture(name="importer")
+def truelayer_importer_fixture(tmp_config):
+    importer = tlimp.Importer()
+    importer._configure(tmp_config, [])
+    yield importer
 
 
 @pytest.fixture(name="tmp_trx")

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -87,16 +87,12 @@ def test_identify(importer, tmp_config):
 
 
 def test_extract_transaction_simple(importer, tmp_trx):
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     assert entries[0].postings[0].units.number == D(str(tmp_trx["amount"]))
 
 
 def test_extract_transaction_with_balance(importer, tmp_trx):
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     # one entry, one balance
     assert len(entries) == 2
     assert entries[1].amount.number == D(str(tmp_trx["running_balance"]["amount"]))
@@ -104,48 +100,38 @@ def test_extract_transaction_with_balance(importer, tmp_trx):
 
 def test_extract_transaction_invert_sign(importer, tmp_trx):
     """Show that sign inversion works"""
-    entries = importer._extract_transaction(tmp_trx, "GBP", [tmp_trx], invert_sign=True)
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=True)
     assert entries[0].postings[0].units.number == -D(str(tmp_trx["amount"]))
 
 
 @pytest.mark.parametrize("id_field", tlimp.TX_MANDATORY_ID_FIELDS)
 def test_extract_transaction_has_transaction_id(importer, tmp_trx, id_field):
     """Ensure mandatory IDs are in extracted transactions."""
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     assert entries[0].meta[id_field] == tmp_trx[id_field]
 
 
 @pytest.mark.parametrize("id_field", tlimp.TX_OPTIONAL_ID_FIELDS)
 def test_trx_id(importer, tmp_trx, id_field):
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     assert entries[0].meta[id_field] == tmp_trx[id_field]
 
 
 @pytest.mark.parametrize("id_field", tlimp.TX_OPTIONAL_ID_FIELDS)
 def test_trx_id_is_optional(importer, id_field):
     tmp_trx = json.loads(TEST_TRX_WITHOUT_IDS)
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     assert entries[0].meta.get(id_field) is None
 
 
 @pytest.mark.parametrize("id_field", tlimp.TX_OPTIONAL_META_ID_FIELDS)
 def test_trx_meta_id(importer, tmp_trx, id_field):
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     assert entries[0].meta[id_field] == tmp_trx["meta"][id_field]
 
 
 @pytest.mark.parametrize("id_field", tlimp.TX_OPTIONAL_META_ID_FIELDS)
 def test_trx_meta_id_is_optional(importer, id_field):
     tmp_trx = json.loads(TEST_TRX_WITHOUT_IDS)
-    entries = importer._extract_transaction(
-        tmp_trx, "GBP", [tmp_trx], invert_sign=False
-    )
+    entries = importer._extract_transaction(tmp_trx, [tmp_trx], invert_sign=False)
     assert entries[0].meta.get(id_field) is None


### PR DESCRIPTION
This adds a new (optional) configuration "accounts", e.g.:

```yaml
accounts:
    1aacb311039ecba9: Liabilities:Visa
    ec34db160c61d468: Assets:Savings
```

If no "accounts" config is present the baseAccount is used for all transactions.

If the config is present but an account ID isn't recognized the transactions will be ignored and a warning issued.
