### PR TITLE
Quickfile importer

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -31,6 +31,44 @@ Create a file called bitstamp.yaml in your import location (e.g. downloads folde
   CONFIG = [bitstimp.Importer()]
 
 
+QuickFile
+--------------
+Import from `QuickFile <https://www.quickfile.co.uk/>`__ using their API services.
+Supports a `range of (mostly UK) banks <https://www.quickfile.co.uk/openbanking/providers>`__.
+
+Requires a QuickFile account (any pricing plan, including free) but with a paid
+Automated Bank Feed subscription (`small annual fee <https://www.quickfile.co.uk/home/pricing>`__).
+
+It is assumed you already have automated bank feeds configured within QuickFile
+for the accounts of interest and are able to browse transactions within the QuickFile dashboard.
+
+.. code-block:: python
+
+  from tariochbctools.importers.quickfile import importer as qfimp
+
+  CONFIG = [qfimp.Importer()]
+
+Create a file called ``quickfile.yaml`` in your import location (e.g. download folder).
+
+.. code-block:: yaml
+
+  account_number: "YOUR_ACCOUNT_NUMBER"
+  api_key: YOUR_API_KEY
+  app_id: YOUR_APP_ID
+  accounts:
+      1200: Assets:Other
+      1201: Assets:Savings
+  transaction_count: 200
+
+
+To obtain an API key you must create an app in the `Account Settings | 3rd
+Party Integration | API` section of your account dashboard.
+
+Accounts are indexed in the config by their ``nominal code`` (typically: ~1200)
+visible in each account's settings. Only accounts listed in the config will be
+queried.
+
+
 Revolut
 -------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     camelot-py[cv]
     blockcypher
     imap-tools
+    undictify
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
@@ -65,6 +66,7 @@ exclude =
 testing =
     pytest
     pytest-cov
+    pytest-mock
     flake8
     black
     isort

--- a/src/tariochbctools/importers/quickfile/importer.py
+++ b/src/tariochbctools/importers/quickfile/importer.py
@@ -131,13 +131,13 @@ class QuickFile:
 
         return r
 
-    def bank_search(self, account_number):
+    def bank_search(self, account_number, transaction_count):
         endpoint_data = {
             "SearchParameters": {
-                "ReturnCount": "10",
+                "ReturnCount": str(transaction_count),
                 "Offset": "0",
                 "OrderResultsBy": "TransactionDate",
-                "OrderDirection": "ASC",
+                "OrderDirection": "DESC",
                 "NominalCode": str(account_number),
             }
         }
@@ -182,7 +182,8 @@ class Importer(importer.ImporterProtocol):
 
     def _extract_bank_transactions(self, bank_account, invert_sign=False):
         entries = []
-        response = self.quickfile.bank_search(bank_account)
+        transaction_count = self.config["transaction_count"]  # [0..200]
+        response = self.quickfile.bank_search(bank_account, transaction_count)
         metadata = response.MetaData
         transactions = response.Transactions["Transaction"]
         local_account = self.config["accounts"].get(bank_account)

--- a/src/tariochbctools/importers/quickfile/importer.py
+++ b/src/tariochbctools/importers/quickfile/importer.py
@@ -1,14 +1,16 @@
+import logging
+import uuid
 from datetime import datetime
+from hashlib import md5
 from os import path
-from typing import NamedTuple
+from typing import Dict, List, NamedTuple
 
+import requests
 import yaml
 from beancount.core import amount, data
 from beancount.core.number import D
 from beancount.ingest import importer
 from undictify import type_checked_constructor
-
-# https://api.quickfile.co.uk/method/bank
 
 
 @type_checked_constructor(skip=True, convert=True)
@@ -17,9 +19,9 @@ class QuickFileTransaction(NamedTuple):
 
     TransactionDate: str
     Reference: str
-    Amount: float
+    Amount: str  # otherwise tiny conversion losses
     TagStatus: str
-    TransactionId: int
+    TransactionId: str
 
     def to_beancount_transaction(self, local_account, currency, invert_sign=False):
         tx_amount = D(self.Amount)
@@ -31,7 +33,7 @@ class QuickFileTransaction(NamedTuple):
         }
 
         meta = data.new_metadata("", 0, metakv)
-        date = datetime.fromisoformat(self.TransactionDate)
+        date = datetime.fromisoformat(self.TransactionDate).date()
 
         entry = data.Transaction(
             meta,
@@ -55,16 +57,112 @@ class QuickFileTransaction(NamedTuple):
         return entry
 
 
+@type_checked_constructor(skip=True, convert=True)
+class QuickFileResponseMetaData(NamedTuple):
+    RecordsetCount: int
+    ReturnCount: int
+    BankName: str
+    BankType: str
+    AccountNo: str
+    SortCode: str
+    Currency: str
+    CurrentBalance: str
+
+
+@type_checked_constructor(skip=True, convert=True)
+class QuickFileBankSearch(NamedTuple):
+    MetaData: QuickFileResponseMetaData
+    Transactions: Dict[str, List[QuickFileTransaction]]
+
+
+class QuickFile:
+    """Encapsulate QuickFile API protocol and data types"""
+
+    DOMAIN = "quickfile.co.uk"
+    API_VERSION_SLUG = "1_2"
+
+    def __init__(self, account_number, api_key, app_id):
+        self.account_number = account_number
+        self.api_key = api_key
+        self.app_id = app_id
+        self._update_submission_number()
+
+    @staticmethod
+    def auth_md5(account_number, api_key, submission_number):
+        md5_str = (account_number + api_key + str(submission_number)).encode("utf-8")
+
+        return md5(md5_str).hexdigest()
+
+    def request_header(self):
+        auth_md5 = self.auth_md5(
+            self.account_number, self.api_key, self.submission_number
+        )
+
+        header = {
+            "MessageType": "Request",
+            "SubmissionNumber": str(self.submission_number),
+            "Authentication": {
+                "AccNumber": str(self.account_number),
+                "MD5Value": auth_md5,
+                "ApplicationID": str(self.app_id),
+            },
+        }
+        return header
+
+    def _update_submission_number(self):
+        self.submission_number = uuid.uuid4()
+
+    def _post(self, endpoint, endpoint_data):
+        header = self.request_header()
+        post_data = {"payload": {"Header": header, "Body": endpoint_data}}
+
+        r = requests.post(
+            f"https://api.{self.DOMAIN}/{self.API_VERSION_SLUG}/{endpoint}",
+            json=post_data,
+        )
+
+        if not r:
+            try:
+                r.raise_for_status()
+            except requests.HTTPError as e:
+                logging.warning(e)
+
+        self._update_submission_number()
+
+        return r
+
+    def bank_search(self, account_number):
+        endpoint_data = {
+            "SearchParameters": {
+                "ReturnCount": "10",
+                "Offset": "0",
+                "OrderResultsBy": "TransactionDate",
+                "OrderDirection": "ASC",
+                "NominalCode": str(account_number),
+            }
+        }
+
+        response = self._post("bank/search", endpoint_data).json()
+        body = response["Bank_Search"]["Body"]
+        return QuickFileBankSearch(**body)
+
+
 class Importer(importer.ImporterProtocol):
     """An importer for QuickFile"""
 
     def __init__(self):
+        self.quickfile = None
         self.config = None
         self.existing_entries = None
 
     def _configure(self, file, existing_entries):
         with open(file.name, "r") as config_file:
             self.config = yaml.safe_load(config_file)
+            self.quickfile = QuickFile(
+                account_number=self.config["account_number"],
+                api_key=self.config["api_key"],
+                app_id=self.config["app_id"],
+            )
         self.existing_entries = existing_entries
 
     def identify(self, file):
@@ -75,29 +173,37 @@ class Importer(importer.ImporterProtocol):
 
     def extract(self, file, existing_entries=None):
         self._configure(file, existing_entries)
-        headers = {}
         entries = []
-        entries.extend(self._extract_bank_transactions("account_one", headers))
+
+        for bank_account in self.config["accounts"].keys():
+            entries.extend(self._extract_bank_transactions(bank_account))
+
         return entries
 
-    def _extract_bank_transactions(self, bank_account, headers, invert_sign=False):
+    def _extract_bank_transactions(self, bank_account, invert_sign=False):
         entries = []
-        response = {}
-        transactions = response
+        response = self.quickfile.bank_search(bank_account)
+        metadata = response.MetaData
+        transactions = response.Transactions["Transaction"]
+        local_account = self.config["accounts"].get(bank_account)
 
-        for trx in response:
+        for trx in transactions:
             entries.extend(
-                self._extract_transaction(trx, bank_account, transactions, invert_sign)
+                self._extract_transaction(
+                    trx, local_account, metadata, transactions, invert_sign
+                )
             )
 
         return entries
 
-    def _extract_transaction(self, trx, local_account, transactions, invert_sign):
+    def _extract_transaction(
+        self, trx, local_account, metadata, transactions, invert_sign
+    ):
         entries = []
-        currency = ""  # TODO: extract from metadata
 
-        t = QuickFileTransaction(**trx)
-        entry = t.to_beancount_transaction(local_account, currency, invert_sign)
+        entry = trx.to_beancount_transaction(
+            local_account, metadata.Currency, invert_sign
+        )
         entries.append(entry)
 
         return entries

--- a/src/tariochbctools/importers/quickfile/importer.py
+++ b/src/tariochbctools/importers/quickfile/importer.py
@@ -1,0 +1,31 @@
+from os import path
+
+import yaml
+from beancount.ingest import importer
+
+# https://api.quickfile.co.uk/method/bank
+
+
+class Importer(importer.ImporterProtocol):
+    """An importer for QuickFile"""
+
+    def __init__(self):
+        self.config = None
+        self.existing_entries = None
+
+    def _configure(self, file, existing_entries):
+        with open(file.name, "r") as config_file:
+            self.config = yaml.safe_load(config_file)
+        self.existing_entries = existing_entries
+
+    def identify(self, file):
+        return path.basename(file.name) == "quickfile.yaml"
+
+    def file_account(self, file):
+        return ""
+
+    def extract(self, file, existing_entries=None):
+        self._configure(file, existing_entries)
+
+        entries = []
+        return entries

--- a/src/tariochbctools/importers/quickfile/importer.py
+++ b/src/tariochbctools/importers/quickfile/importer.py
@@ -1,9 +1,58 @@
+from datetime import datetime
 from os import path
+from typing import NamedTuple
 
 import yaml
+from beancount.core import amount, data
+from beancount.core.number import D
 from beancount.ingest import importer
+from undictify import type_checked_constructor
 
 # https://api.quickfile.co.uk/method/bank
+
+
+@type_checked_constructor(skip=True, convert=True)
+class QuickFileTransaction(NamedTuple):
+    """Transaction data from QuickFile transaction API"""
+
+    TransactionDate: str
+    Reference: str
+    Amount: float
+    TagStatus: str
+    TransactionId: int
+
+    def to_beancount_transaction(self, local_account, currency, invert_sign=False):
+        tx_amount = D(self.Amount)
+        # avoid pylint invalid-unary-operand-type
+        signed_amount = -1 * tx_amount if invert_sign else tx_amount
+
+        metakv = {
+            "quickfile_id": self.TransactionId,
+        }
+
+        meta = data.new_metadata("", 0, metakv)
+        date = datetime.fromisoformat(self.TransactionDate)
+
+        entry = data.Transaction(
+            meta,
+            date,
+            "*",
+            "",
+            self.Reference,
+            data.EMPTY_SET,
+            data.EMPTY_SET,
+            [
+                data.Posting(
+                    local_account,
+                    amount.Amount(signed_amount, currency),
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        return entry
 
 
 class Importer(importer.ImporterProtocol):
@@ -26,6 +75,29 @@ class Importer(importer.ImporterProtocol):
 
     def extract(self, file, existing_entries=None):
         self._configure(file, existing_entries)
-
+        headers = {}
         entries = []
+        entries.extend(self._extract_bank_transactions("account_one", headers))
+        return entries
+
+    def _extract_bank_transactions(self, bank_account, headers, invert_sign=False):
+        entries = []
+        response = {}
+        transactions = response
+
+        for trx in response:
+            entries.extend(
+                self._extract_transaction(trx, bank_account, transactions, invert_sign)
+            )
+
+        return entries
+
+    def _extract_transaction(self, trx, local_account, transactions, invert_sign):
+        entries = []
+        currency = ""  # TODO: extract from metadata
+
+        t = QuickFileTransaction(**trx)
+        entry = t.to_beancount_transaction(local_account, currency, invert_sign)
+        entries.append(entry)
+
         return entries

--- a/tests/tariochbctools/importers/test_quickfile.py
+++ b/tests/tariochbctools/importers/test_quickfile.py
@@ -17,6 +17,7 @@ app_id: SOME_APP_ID
 accounts:
     1200: Assets:Other
     1201: Assets:Savings
+transaction_count: 200
 """
 
 # Example from the quickfile API docs

--- a/tests/tariochbctools/importers/test_quickfile.py
+++ b/tests/tariochbctools/importers/test_quickfile.py
@@ -1,7 +1,9 @@
 import json
+from unittest.mock import MagicMock, call
 
 import pytest
-from beancount.core.amount import Decimal as D
+from beancount.core import data
+from beancount.core.number import D
 from beancount.ingest import cache
 
 from tariochbctools.importers.quickfile import importer as qfimp
@@ -9,6 +11,12 @@ from tariochbctools.importers.quickfile import importer as qfimp
 # pylint: disable=protected-access
 
 TEST_CONFIG = b"""
+account_number: "YOUR_ACCOUNT_NUMBER"
+api_key: SOME_API_KEY
+app_id: SOME_APP_ID
+accounts:
+    1200: Assets:Other
+    1201: Assets:Savings
 """
 
 # Example from the quickfile API docs
@@ -19,6 +27,53 @@ TEST_TRX = b"""
     "Amount": -4.75,
     "TagStatus": null,
     "TransactionId": 666
+}
+"""
+
+TEST_META_DATA = b"""
+{
+    "RecordsetCount": 6853,
+    "ReturnCount": 1,
+    "BankName": "Current Account",
+    "BankType": "CURRENT",
+    "AccountNo": "90145741",
+    "SortCode": "208246",
+    "Currency": "GBP",
+    "CurrentBalance": 3164.97
+}
+"""
+
+TEST_BANK_SEARCH = b"""
+{
+  "Bank_Search": {
+    "Header": {
+      "MessageType": "Response",
+      "SubmissionNumber": "8ebba60a-95ce-44af-a8c7-e827ac1ae117"
+    },
+    "Body": {
+      "MetaData": {
+        "RecordsetCount": 6853,
+        "ReturnCount": 1,
+        "BankName": "Current Account",
+        "BankType": "CURRENT",
+        "AccountNo": "90145741",
+        "SortCode": "208246",
+        "Currency": "GBP",
+        "CurrentBalance": 3164.97
+      },
+      "Transactions": {
+        "Transaction": [
+          {
+            "TransactionDate": "2017-01-04T00:00:00",
+            "Reference": "WATERSTONES REF 364 2177333010 BCC",
+            "Amount": -4.75,
+            "TagStatus": null,
+            "TransactionId": 0
+          }
+        ]
+      }
+    }
+  }
 }
 """
 
@@ -55,15 +110,68 @@ def quickfile_importer_factory(tmp_path):
 
 @pytest.fixture(name="tmp_trx")
 def tmp_trx_fixture():
-    yield json.loads(TEST_TRX)
+    j = json.loads(TEST_TRX)
+    yield qfimp.QuickFileTransaction(**j)
+
+
+@pytest.fixture(name="tmp_metadata")
+def tmp_metadata_fixture():
+    j = json.loads(TEST_META_DATA)
+    metadata = qfimp.QuickFileResponseMetaData(**j)
+    yield metadata
 
 
 def test_identify(importer, tmp_config):
     assert importer.identify(tmp_config)
 
 
-def test_extract_transaction_simple(importer, tmp_trx):
+def test_extract_transaction_simple(importer, tmp_trx, tmp_metadata):
     entries = importer._extract_transaction(
-        tmp_trx, "Assets:Other", [tmp_trx], invert_sign=False
+        tmp_trx, "Assets:Other", tmp_metadata, [tmp_trx], invert_sign=False
     )
-    assert entries[0].postings[0].units.number == D(str(tmp_trx["Amount"]))
+    data.sanity_check_types(entries[0])
+
+
+def test_extract_transaction_invert_sign(importer, tmp_trx, tmp_metadata):
+    """Show that sign inversion works"""
+    entries = importer._extract_transaction(
+        tmp_trx, "Assets:Other", tmp_metadata, [tmp_trx], invert_sign=True
+    )
+    assert entries[0].postings[0].units.number == -D(str(tmp_trx.Amount))
+
+
+def test_extract_transaction_has_quickfile_id(importer, tmp_trx, tmp_metadata):
+    """Ensure mandatory IDs are in extracted transactions."""
+    entries = importer._extract_transaction(
+        tmp_trx, "Assets:Other", tmp_metadata, [tmp_trx], invert_sign=False
+    )
+    assert "quickfile_id" in entries[0].meta
+
+
+def test_request_header_auth(importer, tmp_config):
+    header = importer.quickfile.request_header()
+    auth = header.get("Authentication")
+
+    config = importer.config
+
+    assert auth["AccNumber"] == config["account_number"]
+    assert auth["MD5Value"] == importer.quickfile.auth_md5(
+        config["account_number"],
+        config["api_key"],
+        importer.quickfile.submission_number,
+    )
+    assert auth["ApplicationID"] == config["app_id"]
+
+
+def test_bank_search():
+    response = json.loads(TEST_BANK_SEARCH)
+    body = response["Bank_Search"]["Body"]
+    bs = qfimp.QuickFileBankSearch(**body)
+    assert len(bs.Transactions["Transaction"]) == 1
+
+
+def test_extract_all_accounts(importer, tmp_config):
+    importer._extract_bank_transactions = MagicMock()
+    importer.extract(tmp_config)
+    calls = [call(1200), call(1201)]
+    importer._extract_bank_transactions.assert_has_calls(calls, any_order=True)

--- a/tests/tariochbctools/importers/test_quickfile.py
+++ b/tests/tariochbctools/importers/test_quickfile.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+from beancount.ingest import cache
+
+from tariochbctools.importers.quickfile import importer as qfimp
+
+# pylint: disable=protected-access
+
+TEST_CONFIG = b"""
+"""
+
+# Example from the quickfile API docs
+TEST_TRX = b"""
+"""
+
+
+@pytest.fixture(name="tmp_config")
+def tmp_config_fixture(tmp_path):
+    config = tmp_path / "quickfile.yaml"
+    config.write_bytes(TEST_CONFIG)
+    yield cache.get_file(config)  # a FileMemo, not a Path
+
+
+@pytest.fixture(name="importer")
+def quickfile_importer_fixture(tmp_config):
+    importer = qfimp.Importer()
+    importer._configure(tmp_config, [])
+    yield importer
+
+
+@pytest.fixture(name="importer_factory")
+def quickfile_importer_factory(tmp_path):
+    """A quickfile importer factory for
+    generating an importer with a custom config
+    """
+
+    def _importer_with_config(custom_config):
+        config = tmp_path / "quickfile.yaml"
+        config.write_bytes(custom_config)
+        importer = qfimp.Importer()
+        importer._configure(cache.get_file(config), [])
+        return importer
+
+    yield _importer_with_config
+
+
+@pytest.fixture(name="tmp_trx")
+def tmp_trx_fixture():
+    yield json.loads(TEST_TRX)
+
+
+def test_identify(importer, tmp_config):
+    assert importer.identify(tmp_config)

--- a/tests/tariochbctools/importers/test_quickfile.py
+++ b/tests/tariochbctools/importers/test_quickfile.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from beancount.core.amount import Decimal as D
 from beancount.ingest import cache
 
 from tariochbctools.importers.quickfile import importer as qfimp
@@ -12,6 +13,13 @@ TEST_CONFIG = b"""
 
 # Example from the quickfile API docs
 TEST_TRX = b"""
+{
+    "TransactionDate": "2017-01-04T12:34:56",
+    "Reference": "WATERSTONES REF 364 2177333010 BCC",
+    "Amount": -4.75,
+    "TagStatus": null,
+    "TransactionId": 666
+}
 """
 
 
@@ -52,3 +60,10 @@ def tmp_trx_fixture():
 
 def test_identify(importer, tmp_config):
     assert importer.identify(tmp_config)
+
+
+def test_extract_transaction_simple(importer, tmp_trx):
+    entries = importer._extract_transaction(
+        tmp_trx, "Assets:Other", [tmp_trx], invert_sign=False
+    )
+    assert entries[0].postings[0].units.number == D(str(tmp_trx["Amount"]))


### PR DESCRIPTION
This adds an importer for https://quickfile.co.uk which supports a number of UK banks including some (like CaterAllen) supported by no other OpenBanking providers.

It does not (yet) generate `balance` postings.
