### PR TITLE
Update Transferwise (now Wise) to support SCA

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -107,6 +107,7 @@ The final command makes a traditional private key for compatibility with the pyt
 
 Now upload the *public* key part to your Wise account.
 
+You can then create an import config for beancount, or add Wise to your existing one.
 
 .. code-block:: python
 

--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -88,10 +88,25 @@ Import CSV from `Revolut <https://www.revolut.com/>`__
   CONFIG = [revolutimp.Importer("/Revolut-CHF.*\.csv", "Assets:Revolut:CHF", "CHF")]
 
 
-Transferwise
-------------
+Wise (formerly Transferwise)
+----------------------------
 
-Import from `Transferwise <https://www.transferwise.com/>`__ using their api
+Import from `Wise <https://www.wise.com/>`__ using their api.
+
+First, generate a personal API token by logging on and going to settings.
+Next, you need to generate a public/private key pair and then upload the public
+key part to your account. To generate the keys, execute (e.g. in your ``.ssh`` folder)
+
+.. code-block:: bash
+
+   openssl genrsa -out wise.pem
+   openssl rsa -pubout -in wise.pem -out wise_public.pem
+   openssl pkey -in wise.pem -traditional > wise_traditional.pem
+
+The final command makes a traditional private key for compatibility with the python rsa library. This may stop being necessary at some point. See `this page https://github.com/sybrenstuvel/python-rsa/issues/80` for details.
+
+Now upload the *public* key part to your Wise account.
+
 
 .. code-block:: python
 
@@ -105,6 +120,7 @@ Create a file called transferwise.yaml in your import location (e.g. download fo
 
   token: <your api token>
   baseAccount: <Assets:Transferwise:>
+  privateKeyPath: /path/to/wise_traditional.pem
 
 
 TrueLayer

--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -123,6 +123,19 @@ Create a file called transferwise.yaml in your import location (e.g. download fo
   privateKeyPath: /path/to/wise_traditional.pem
 
 
+Optionally, you can provide a dictionary of account names mapped by currency. In this case
+you must provide a name for every currency in your Wise account, otherwise the import will
+fail.
+
+
+.. code-block:: yaml
+
+  token: <your api token>
+  baseAccount:
+    SEK: "Assets:MySwedishWiseAccount"
+    GBP: "Assets:MyUKWiseAccount"
+  privateKeyPath: /path/to/wise_traditional.pem
+
 TrueLayer
 ---------
 

--- a/src/tariochbctools/importers/transferwise/importer.py
+++ b/src/tariochbctools/importers/transferwise/importer.py
@@ -4,10 +4,16 @@ from os import path
 import dateutil.parser
 import requests
 import yaml
+import base64
 from beancount.core import amount, data
 from beancount.core.number import D
 from beancount.ingest import importer
 from dateutil.relativedelta import relativedelta
+import urllib3
+from urllib.parse import urlencode
+import rsa
+import json
+http = urllib3.PoolManager()
 
 
 class Importer(importer.ImporterProtocol):
@@ -19,11 +25,85 @@ class Importer(importer.ImporterProtocol):
     def file_account(self, file):
         return ""
 
+    # Based on the Transferwise official example provided under the
+    # MIT license
+    def _get_statement(self, api_token, interval_start, interval_end, currency, base_url, private_key_path, profile_id, account_id, one_time_token="", signature="", statement_type='FLAT'):
+
+        params = urlencode({
+            'currency': currency, 'type': statement_type,
+            'intervalStart': interval_start,
+            'intervalEnd': interval_end})
+
+        url = (
+            base_url + '/v3/profiles/' + profile_id + '/borderless-accounts/' 
+            + account_id + '/statement.json?' + params)
+
+        headers = {
+            'Authorization': 'Bearer ' + api_token,
+            'User-Agent': 'tw-statements-sca',
+            'Content-Type': 'application/json'}
+        if one_time_token != "":
+            headers['x-2fa-approval'] = one_time_token
+            headers['X-Signature'] = signature
+            print(headers['x-2fa-approval'], headers['X-Signature'])
+
+        print('GET', url)
+
+        r = http.request('GET', url, headers=headers, retries=False)
+
+        print('status:', r.status)
+        
+        if r.status == 200 or r.status == 201:
+            return json.loads(r.data)
+        elif r.status == 403 and r.getheader('x-2fa-approval') is not None:
+            one_time_token = r.getheader('x-2fa-approval')
+            signature = Importer._do_sca_challenge(one_time_token=one_time_token, private_key_path=private_key_path)
+            return self._get_statement(
+                api_token=api_token,
+                one_time_token=one_time_token,
+                signature=signature,
+                interval_start=interval_start,
+                interval_end=interval_end,
+                currency=currency,
+                base_url=base_url,
+                private_key_path=private_key_path,
+                account_id=account_id,
+                profile_id=profile_id,
+                statement_type=statement_type)
+        else:
+            print('failed: ', r.status)
+            print(r.data)
+            sys.exit(0)
+
+    @staticmethod
+    def _do_sca_challenge(one_time_token, private_key_path):
+        print('doing sca challenge')
+
+        # Read the private key file as bytes.
+        with open(private_key_path, 'rb') as f:
+            private_key_data = f.read()
+
+        private_key = rsa.PrivateKey.load_pkcs1(private_key_data, 'PEM')
+
+        # Use the private key to sign the one-time-token that was returned 
+        # in the x-2fa-approval header of the HTTP 403.
+        signed_token = rsa.sign(
+            one_time_token.encode('ascii'), 
+            private_key, 
+            'SHA-256')
+
+        # Encode the signed message as friendly base64 format for HTTP 
+        # headers.
+        signature = base64.b64encode(signed_token).decode('ascii')
+
+        return signature
+
     def extract(self, file, existing_entries):
         with open(file.name, "r") as f:
             config = yaml.safe_load(f)
         token = config["token"]
         baseAccount = config["baseAccount"]
+        private_key_path = config["privateKeyPath"]
         startDate = datetime.combine(
             date.today() + relativedelta(months=-3), datetime.min.time(), timezone.utc
         ).isoformat()
@@ -45,19 +125,21 @@ class Importer(importer.ImporterProtocol):
         accountId = accounts[0]["id"]
 
         entries = []
+        base_url = 'https://api.transferwise.com'
         for account in accounts[0]["balances"]:
             accountCcy = account["currency"]
 
-            r = requests.get(
-                f"https://api.transferwise.com/v3/profiles/{profileId}/borderless-accounts/{accountId}/statement.json",
-                params={
-                    "currency": accountCcy,
-                    "intervalStart": startDate,
-                    "intervalEnd": endDate,
-                },
-                headers=headers,
-            )
-            transactions = r.json()
+#             r = requests.get(
+#                 f"https://api.transferwise.com/v3/profiles/{profileId}/borderless-accounts/{accountId}/statement.json",
+#                 params={
+#                     "currency": accountCcy,
+#                     "intervalStart": startDate,
+#                     "intervalEnd": endDate,
+#                 },
+#                 headers=headers,
+#             )
+#             transactions = r.json()
+            transactions = self._get_statement(api_token=token, interval_start=startDate, interval_end=endDate, currency=accountCcy, base_url=base_url, private_key_path=private_key_path, profile_id=str(profileId), account_id=str(accountId), statement_type='FLAT')
 
             for transaction in transactions["transactions"]:
                 metakv = {

--- a/src/tariochbctools/importers/transferwise/importer.py
+++ b/src/tariochbctools/importers/transferwise/importer.py
@@ -148,7 +148,7 @@ class Importer(importer.ImporterProtocol):
             accountCcy = account["currency"]
             if isinstance(baseAccount, dict):
                 account_name = baseAccount[accountCcy]
-            else: 
+            else:
                 account_name = baseAccount + accountCcy
             transactions = self._get_statement(
                 currency=accountCcy,

--- a/src/tariochbctools/importers/transferwise/importer.py
+++ b/src/tariochbctools/importers/transferwise/importer.py
@@ -13,6 +13,7 @@ import urllib3
 from urllib.parse import urlencode
 import rsa
 import json
+
 http = urllib3.PoolManager()
 
 
@@ -27,37 +28,62 @@ class Importer(importer.ImporterProtocol):
 
     # Based on the Transferwise official example provided under the
     # MIT license
-    def _get_statement(self, api_token, interval_start, interval_end, currency, base_url, private_key_path, profile_id, account_id, one_time_token="", signature="", statement_type='FLAT'):
-
-        params = urlencode({
-            'currency': currency, 'type': statement_type,
-            'intervalStart': interval_start,
-            'intervalEnd': interval_end})
+    def _get_statement(
+        self,
+        api_token,
+        interval_start,
+        interval_end,
+        currency,
+        base_url,
+        private_key_path,
+        profile_id,
+        account_id,
+        one_time_token="",
+        signature="",
+        statement_type="FLAT",
+    ):
+        params = urlencode(
+            {
+                "currency": currency,
+                "type": statement_type,
+                "intervalStart": interval_start,
+                "intervalEnd": interval_end,
+            }
+        )
 
         url = (
-            base_url + '/v3/profiles/' + profile_id + '/borderless-accounts/' 
-            + account_id + '/statement.json?' + params)
+            base_url
+            + "/v3/profiles/"
+            + profile_id
+            + "/borderless-accounts/"
+            + account_id
+            + "/statement.json?"
+            + params
+        )
 
         headers = {
-            'Authorization': 'Bearer ' + api_token,
-            'User-Agent': 'tw-statements-sca',
-            'Content-Type': 'application/json'}
+            "Authorization": "Bearer " + api_token,
+            "User-Agent": "tw-statements-sca",
+            "Content-Type": "application/json",
+        }
         if one_time_token != "":
-            headers['x-2fa-approval'] = one_time_token
-            headers['X-Signature'] = signature
-            print(headers['x-2fa-approval'], headers['X-Signature'])
+            headers["x-2fa-approval"] = one_time_token
+            headers["X-Signature"] = signature
+            print(headers["x-2fa-approval"], headers["X-Signature"])
 
-        print('GET', url)
+        print("GET", url)
 
-        r = http.request('GET', url, headers=headers, retries=False)
+        r = http.request("GET", url, headers=headers, retries=False)
 
-        print('status:', r.status)
-        
+        print("status:", r.status)
+
         if r.status == 200 or r.status == 201:
             return json.loads(r.data)
-        elif r.status == 403 and r.getheader('x-2fa-approval') is not None:
-            one_time_token = r.getheader('x-2fa-approval')
-            signature = Importer._do_sca_challenge(one_time_token=one_time_token, private_key_path=private_key_path)
+        elif r.status == 403 and r.getheader("x-2fa-approval") is not None:
+            one_time_token = r.getheader("x-2fa-approval")
+            signature = Importer._do_sca_challenge(
+                one_time_token=one_time_token, private_key_path=private_key_path
+            )
             return self._get_statement(
                 api_token=api_token,
                 one_time_token=one_time_token,
@@ -69,32 +95,30 @@ class Importer(importer.ImporterProtocol):
                 private_key_path=private_key_path,
                 account_id=account_id,
                 profile_id=profile_id,
-                statement_type=statement_type)
+                statement_type=statement_type,
+            )
         else:
-            print('failed: ', r.status)
+            print("failed: ", r.status)
             print(r.data)
             sys.exit(0)
 
     @staticmethod
     def _do_sca_challenge(one_time_token, private_key_path):
-        print('doing sca challenge')
+        print("doing sca challenge")
 
         # Read the private key file as bytes.
-        with open(private_key_path, 'rb') as f:
+        with open(private_key_path, "rb") as f:
             private_key_data = f.read()
 
-        private_key = rsa.PrivateKey.load_pkcs1(private_key_data, 'PEM')
+        private_key = rsa.PrivateKey.load_pkcs1(private_key_data, "PEM")
 
-        # Use the private key to sign the one-time-token that was returned 
+        # Use the private key to sign the one-time-token that was returned
         # in the x-2fa-approval header of the HTTP 403.
-        signed_token = rsa.sign(
-            one_time_token.encode('ascii'), 
-            private_key, 
-            'SHA-256')
+        signed_token = rsa.sign(one_time_token.encode("ascii"), private_key, "SHA-256")
 
-        # Encode the signed message as friendly base64 format for HTTP 
+        # Encode the signed message as friendly base64 format for HTTP
         # headers.
-        signature = base64.b64encode(signed_token).decode('ascii')
+        signature = base64.b64encode(signed_token).decode("ascii")
 
         return signature
 
@@ -125,21 +149,31 @@ class Importer(importer.ImporterProtocol):
         accountId = accounts[0]["id"]
 
         entries = []
-        base_url = 'https://api.transferwise.com'
+        base_url = "https://api.transferwise.com"
         for account in accounts[0]["balances"]:
             accountCcy = account["currency"]
 
-#             r = requests.get(
-#                 f"https://api.transferwise.com/v3/profiles/{profileId}/borderless-accounts/{accountId}/statement.json",
-#                 params={
-#                     "currency": accountCcy,
-#                     "intervalStart": startDate,
-#                     "intervalEnd": endDate,
-#                 },
-#                 headers=headers,
-#             )
-#             transactions = r.json()
-            transactions = self._get_statement(api_token=token, interval_start=startDate, interval_end=endDate, currency=accountCcy, base_url=base_url, private_key_path=private_key_path, profile_id=str(profileId), account_id=str(accountId), statement_type='FLAT')
+            #             r = requests.get(
+            #                 f"https://api.transferwise.com/v3/profiles/{profileId}/borderless-accounts/{accountId}/statement.json",
+            #                 params={
+            #                     "currency": accountCcy,
+            #                     "intervalStart": startDate,
+            #                     "intervalEnd": endDate,
+            #                 },
+            #                 headers=headers,
+            #             )
+            #             transactions = r.json()
+            transactions = self._get_statement(
+                api_token=token,
+                interval_start=startDate,
+                interval_end=endDate,
+                currency=accountCcy,
+                base_url=base_url,
+                private_key_path=private_key_path,
+                profile_id=str(profileId),
+                account_id=str(accountId),
+                statement_type="FLAT",
+            )
 
             for transaction in transactions["transactions"]:
                 metakv = {

--- a/src/tariochbctools/importers/transferwise/importer.py
+++ b/src/tariochbctools/importers/transferwise/importer.py
@@ -1,18 +1,19 @@
+import base64
+import json
+import sys
 from datetime import date, datetime, timezone
 from os import path
+from urllib.parse import urlencode
 
 import dateutil.parser
 import requests
+import rsa
+import urllib3
 import yaml
-import base64
 from beancount.core import amount, data
 from beancount.core.number import D
 from beancount.ingest import importer
 from dateutil.relativedelta import relativedelta
-import urllib3
-from urllib.parse import urlencode
-import rsa
-import json
 
 http = urllib3.PoolManager()
 

--- a/src/tariochbctools/importers/transferwise/importer.py
+++ b/src/tariochbctools/importers/transferwise/importer.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import sys
 from datetime import date, datetime, timezone
 from os import path
 from urllib.parse import urlencode
@@ -79,13 +78,8 @@ class Importer(importer.ImporterProtocol):
         if hasattr(self, "one_time_token"):
             headers["x-2fa-approval"] = self.one_time_token
             headers["X-Signature"] = self.signature
-            print(headers["x-2fa-approval"], headers["X-Signature"])
-
-        print("GET", url)
 
         r = http.request("GET", url, headers=headers, retries=False)
-
-        print("status:", r.status)
 
         if r.status == 200 or r.status == 201:
             return json.loads(r.data)
@@ -98,13 +92,9 @@ class Importer(importer.ImporterProtocol):
                 statement_type=statement_type,
             )
         else:
-            print("failed: ", r.status)
-            print(r.data)
-            sys.exit(0)
+            raise Exception("Failed to get transactions.")
 
     def _do_sca_challenge(self):
-        print("doing sca challenge")
-
         # Read the private key file as bytes.
         with open(self.private_key_path, "rb") as f:
             private_key_data = f.read()

--- a/src/tariochbctools/importers/transferwise/importer.py
+++ b/src/tariochbctools/importers/transferwise/importer.py
@@ -146,6 +146,10 @@ class Importer(importer.ImporterProtocol):
         base_url = "https://api.transferwise.com"
         for account in accounts[0]["balances"]:
             accountCcy = account["currency"]
+            if isinstance(baseAccount, dict):
+                account_name = baseAccount[accountCcy]
+            else: 
+                account_name = baseAccount + accountCcy
             transactions = self._get_statement(
                 currency=accountCcy,
                 base_url=base_url,
@@ -167,7 +171,7 @@ class Importer(importer.ImporterProtocol):
                     data.EMPTY_SET,
                     [
                         data.Posting(
-                            baseAccount + accountCcy,
+                            account_name,
                             amount.Amount(
                                 D(str(transaction["amount"]["value"])),
                                 transaction["amount"]["currency"],


### PR DESCRIPTION
Getting transactions from Wise requires SCA. See [here](https://docs.wise.com/api-docs/features/strong-customer-authentication-2fa/personal-token-sca). This PR add support for this and thus makes this importer functional again.