### PR TITLE
Add an importer for BCGE MT940 exports.

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -373,3 +373,14 @@ Import PDF from `Viseca One <https://one-digitalservice.ch/>`__
   from tariochbctools.importers.viseca import importer as visecaimp
 
   CONFIG = [visecaimp.Importer(r"Kontoauszug.*\.pdf", "Assets:Viseca:CHF")]
+
+BCGE
+----
+
+Import mt940 from `BCGE <https://www.bcge.ch/>`__
+
+.. code-block:: python
+
+  from tariochbctools.importers.bcge import importer as  bcge
+
+  CONFIG = [bcge.BCGEImporter("/\d+\.mt940", "Assets:BCGE")]

--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -381,6 +381,6 @@ Import mt940 from `BCGE <https://www.bcge.ch/>`__
 
 .. code-block:: python
 
-  from tariochbctools.importers.bcge import importer as  bcge
+  from tariochbctools.importers.bcge import importer as bcge
 
   CONFIG = [bcge.BCGEImporter("/\d+\.mt940", "Assets:BCGE")]

--- a/src/tariochbctools/importers/bcge/importer.py
+++ b/src/tariochbctools/importers/bcge/importer.py
@@ -1,0 +1,31 @@
+import re
+
+from tariochbctools.importers.general import mt940importer
+
+
+def strip_newline(string):
+    return string.replace("\n", "").replace("\r", "")
+
+
+class BCGEImporter(mt940importer.Importer):
+    def prepare_payee(self, trxdata):
+        transaction_details = strip_newline(trxdata["transaction_details"])
+        payee = re.search(r'ORDP/([^/]+)', transaction_details)
+        if payee is None:
+            return ""
+        else:
+            return payee.group(1)
+
+    def prepare_narration(self, trxdata):
+        transaction_details = strip_newline(trxdata["transaction_details"])
+        extra_details = strip_newline(trxdata["extra_details"])
+        beneficiary = re.search(
+            r'/BENM/([^/]+)', transaction_details)
+        remittance = re.search(
+            r'/REMI/([^/]+)', transaction_details)
+        narration = []
+        if beneficiary is not None:
+            narration.append("Beneficiary: %s" % beneficiary.group(1))
+        if remittance is not None:
+            narration.append("Remittance: %s" % remittance.group(1))
+        return ("%s - %s" % (extra_details, ",".join(narration)))

--- a/src/tariochbctools/importers/bcge/importer.py
+++ b/src/tariochbctools/importers/bcge/importer.py
@@ -10,7 +10,7 @@ def strip_newline(string):
 class BCGEImporter(mt940importer.Importer):
     def prepare_payee(self, trxdata):
         transaction_details = strip_newline(trxdata["transaction_details"])
-        payee = re.search(r'ORDP/([^/]+)', transaction_details)
+        payee = re.search(r"ORDP/([^/]+)", transaction_details)
         if payee is None:
             return ""
         else:
@@ -19,13 +19,11 @@ class BCGEImporter(mt940importer.Importer):
     def prepare_narration(self, trxdata):
         transaction_details = strip_newline(trxdata["transaction_details"])
         extra_details = strip_newline(trxdata["extra_details"])
-        beneficiary = re.search(
-            r'/BENM/([^/]+)', transaction_details)
-        remittance = re.search(
-            r'/REMI/([^/]+)', transaction_details)
+        beneficiary = re.search(r"/BENM/([^/]+)", transaction_details)
+        remittance = re.search(r"/REMI/([^/]+)", transaction_details)
         narration = []
         if beneficiary is not None:
             narration.append("Beneficiary: %s" % beneficiary.group(1))
         if remittance is not None:
             narration.append("Remittance: %s" % remittance.group(1))
-        return ("%s - %s" % (extra_details, ",".join(narration)))
+        return "%s - %s" % (extra_details, ",".join(narration))


### PR DESCRIPTION
This importer tries to parse the data that BCGE exports in the transaction detail field, namely ORDP, BENM and REMI.

This should probably be added to the mt940 library, as it's MT940 specific encoding.