### PR TITLE
Add an importer for Swisscard Cashback cards CSV exports.

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -384,3 +384,14 @@ Import mt940 from `BCGE <https://www.bcge.ch/>`__
   from tariochbctools.importers.bcge import importer as bcge
 
   CONFIG = [bcge.BCGEImporter("/\d+\.mt940", "Assets:BCGE")]
+
+Swisscard cards
+---------------
+
+Import Swisscard's `Cashback Cards <https://www.cashback-cards.ch/>` transactions from a CSV export.__
+
+.. code-block:: python
+
+  from tariochbctools.importers.swisscard import importer as swisscard
+
+  CONFIG = [swisscard.SwisscardImporter("swisscard/.*\.csv", "Liabilities:Cashback")]

--- a/src/tariochbctools/importers/swisscard/importer.py
+++ b/src/tariochbctools/importers/swisscard/importer.py
@@ -12,8 +12,7 @@ class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
     """An importer for Swisscard's cashback CSV files."""
 
     def __init__(self, regexps, account):
-        identifier.IdentifyMixin.__init__(
-            self, matchers=[("filename", regexps)])
+        identifier.IdentifyMixin.__init__(self, matchers=[("filename", regexps)])
         self.account = account
 
     def name(self):
@@ -31,8 +30,7 @@ class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
                 skipinitialspace=True,
             )
             for row in reader:
-                book_date = parse(
-                    row["Transaction date"].strip(), dayfirst=True).date()
+                book_date = parse(row["Transaction date"].strip(), dayfirst=True).date()
                 amt = amount.Amount(-D(row["Amount"]), row["Currency"])
                 metakv = {
                     "category": row["Category"],
@@ -48,8 +46,7 @@ class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
                     data.EMPTY_SET,
                     data.EMPTY_SET,
                     [
-                        data.Posting(self.account, amt,
-                                     None, None, None, None),
+                        data.Posting(self.account, amt, None, None, None, None),
                     ],
                 )
                 entries.append(entry)

--- a/src/tariochbctools/importers/swisscard/importer.py
+++ b/src/tariochbctools/importers/swisscard/importer.py
@@ -1,0 +1,57 @@
+import csv
+from io import StringIO
+
+from beancount.core import amount, data
+from beancount.core.number import D
+from beancount.ingest import importer
+from beancount.ingest.importers.mixins import identifier
+from dateutil.parser import parse
+
+
+class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
+    """An importer for Swisscard's cashback CSV files."""
+
+    def __init__(self, regexps, account):
+        identifier.IdentifyMixin.__init__(
+            self, matchers=[("filename", regexps)])
+        self.account = account
+
+    def name(self):
+        return super().name() + self.account
+
+    def file_account(self, file):
+        return self.account
+
+    def extract(self, file, existing_entries):
+        entries = []
+        with StringIO(file.contents()) as csvfile:
+            reader = csv.DictReader(
+                csvfile,
+                delimiter=",",
+                skipinitialspace=True,
+            )
+            for row in reader:
+                book_date = parse(
+                    row["Transaction date"].strip(), dayfirst=True).date()
+                amt = amount.Amount(-D(row["Amount"]), row["Currency"])
+                metakv = {
+                    "category": row["Category"],
+                }
+                meta = data.new_metadata(file.name, 0, metakv)
+                description = row["Description"].strip()
+                entry = data.Transaction(
+                    meta,
+                    book_date,
+                    "*",
+                    "",
+                    description,
+                    data.EMPTY_SET,
+                    data.EMPTY_SET,
+                    [
+                        data.Posting(self.account, amt,
+                                     None, None, None, None),
+                    ],
+                )
+                entries.append(entry)
+
+        return entries


### PR DESCRIPTION
This importer tries to parse the CSV that swisscard exports (which can be retrieved from https://app.swisscard.ch).

It doesn't support currency conversion, as I haven't found a single conversion transaction in my exports.