### PR TITLE
Some of the dividends don't have the "PER SHARE" sub-string

### DIFF
--- a/src/tariochbctools/importers/ibkr/importer.py
+++ b/src/tariochbctools/importers/ibkr/importer.py
@@ -24,8 +24,12 @@ class Importer(importer.ImporterProtocol):
 
     def matches(self, trx, t, account):
         p = re.compile(r".* (?P<perShare>\d+\.?\d+) PER SHARE")
-        trxPerShare = p.search(trx.description).group("perShare")
-        tPerShare = p.search(t["description"]).group("perShare")
+
+        trxPerShareGroups = p.search(trx.description)
+        tPerShareGroups = p.search(t["description"])
+
+        trxPerShare = trxPerShareGroups.group("perShare") if trxPerShareGroups else ''
+        tPerShare = tPerShareGroups.group("perShare") if tPerShareGroups else ''
 
         return (
             t["date"] == trx.dateTime

--- a/src/tariochbctools/importers/ibkr/importer.py
+++ b/src/tariochbctools/importers/ibkr/importer.py
@@ -28,8 +28,8 @@ class Importer(importer.ImporterProtocol):
         trxPerShareGroups = p.search(trx.description)
         tPerShareGroups = p.search(t["description"])
 
-        trxPerShare = trxPerShareGroups.group("perShare") if trxPerShareGroups else ''
-        tPerShare = tPerShareGroups.group("perShare") if tPerShareGroups else ''
+        trxPerShare = trxPerShareGroups.group("perShare") if trxPerShareGroups else ""
+        tPerShare = tPerShareGroups.group("perShare") if tPerShareGroups else ""
 
         return (
             t["date"] == trx.dateTime


### PR DESCRIPTION
Hi :)

While most of the dividends are with this kind of description:
`description='BAH(Ux) CASH DIVIDEND USD 0.47 PER SHARE (Ordinary Dividend)'`
some are of this form:
`description='IFN (USx) STOCK DIVIDEND USx x FOR 1000000000 (Ordinary Dividend)'`

This will cause an `AttributeError: 'NoneType' object has no attribute 'group'` as no "PER SHARE" is found.