### PR TITLE
Make the swisscard importer work with the new statement CSV format.

### DIFF
--- a/src/tariochbctools/importers/swisscard/importer.py
+++ b/src/tariochbctools/importers/swisscard/importer.py
@@ -33,8 +33,8 @@ class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
                 book_date = parse(row["Transaction date"].strip(), dayfirst=True).date()
                 amt = amount.Amount(-D(row["Amount"]), row["Currency"])
                 metakv = {
-                    "Merchant": row["Merchant Category"],
-                    "Category": row["Registered Category"],
+                    "merchant": row["Merchant Category"],
+                    "category": row["Registered Category"],
                 }
                 meta = data.new_metadata(file.name, 0, metakv)
                 description = row["Description"].strip()

--- a/src/tariochbctools/importers/swisscard/importer.py
+++ b/src/tariochbctools/importers/swisscard/importer.py
@@ -33,7 +33,7 @@ class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
                 book_date = parse(row["Transaction date"].strip(), dayfirst=True).date()
                 amt = amount.Amount(-D(row["Amount"]), row["Currency"])
                 metakv = {
-                    "Merchant Category": row["Merchant Category"],
+                    "Merchant": row["Merchant Category"],
                     "Category": row["Registered Category"],
                 }
                 meta = data.new_metadata(file.name, 0, metakv)

--- a/src/tariochbctools/importers/swisscard/importer.py
+++ b/src/tariochbctools/importers/swisscard/importer.py
@@ -33,7 +33,8 @@ class SwisscardImporter(identifier.IdentifyMixin, importer.ImporterProtocol):
                 book_date = parse(row["Transaction date"].strip(), dayfirst=True).date()
                 amt = amount.Amount(-D(row["Amount"]), row["Currency"])
                 metakv = {
-                    "category": row["Category"],
+                    "Merchant Category": row["Merchant Category"],
+                    "Category": row["Registered Category"],
                 }
                 meta = data.new_metadata(file.name, 0, metakv)
                 description = row["Description"].strip()


### PR DESCRIPTION
Somewhen between Jun 4th and Jul 5th, the swisscard statements in CSV format moved from a single Category column to:

- a "Merchant Category" column, which looks like a general category for the merchant.
- a "Registered Category" column, which looks like a string version of the ISO standard MCC code.

Since all statements, previous and past, are now issued with the updated format, it's safe to just modify the importer to make use of the split columns as metadata.