### PR TITLE
[Revolut] Support importing the fees

### DIFF
--- a/src/tariochbctools/importers/revolut/importer.py
+++ b/src/tariochbctools/importers/revolut/importer.py
@@ -69,13 +69,17 @@ class Importer(identifier.IdentifyMixin, importer.ImporterProtocol):
                 ]
                 description = row["Description"].strip()
                 if is_fee_mode:
-                    postings = [data.Posting(self.account, fee, None, None, None, None),
-                                data.Posting(
-                                    self._fee["account"], -fee, None, None, None, None
-                                )]
+                    postings = [
+                        data.Posting(self.account, fee, None, None, None, None),
+                        data.Posting(
+                            self._fee["account"], -fee, None, None, None, None
+                        ),
+                    ]
                     description = f"Fees for {description}"
 
-                assert isinstance(description, str), "Actual type of description is " + str(type(description))
+                assert isinstance(
+                    description, str
+                ), "Actual type of description is " + str(type(description))
 
                 entry = data.Transaction(
                     data.new_metadata(file.name, 0, {}),
@@ -88,7 +92,7 @@ class Importer(identifier.IdentifyMixin, importer.ImporterProtocol):
                     postings,
                 )
                 entries.append(entry)
-            
+
             if not is_fee_mode:
                 # only add balance after the last (newest) transaction
                 try:

--- a/src/tariochbctools/importers/revolut/importer.py
+++ b/src/tariochbctools/importers/revolut/importer.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from io import StringIO
 
 from beancount.core import amount, data
-from beancount.core.number import D
+from beancount.core.number import ZERO, D
 from beancount.ingest import importer
 from beancount.ingest.importers.mixins import identifier
 from dateutil.parser import parse
@@ -103,5 +103,5 @@ class Importer(identifier.IdentifyMixin, importer.ImporterProtocol):
         return entries
 
     @staticmethod
-    def _is_non_zero(raw):
-        return abs(float(raw) - 0.00) > 1e-9
+    def is_non_zero(raw):
+        return raw != ZERO

--- a/src/tariochbctools/importers/revolut/importer.py
+++ b/src/tariochbctools/importers/revolut/importer.py
@@ -47,6 +47,7 @@ class Importer(identifier.IdentifyMixin, importer.ImporterProtocol):
                 skipinitialspace=True,
             )
             next(reader)
+            is_fee_mode = self._fee is not None
             for row in reader:
                 try:
                     bal = D(row["Balance"].replace("'", "").strip())
@@ -60,7 +61,6 @@ class Importer(identifier.IdentifyMixin, importer.ImporterProtocol):
                     logging.warning(e)
                     continue
 
-                is_fee_mode = self._fee is not None
                 if is_fee_mode and fee_amt_raw == ZERO:
                     continue
 


### PR DESCRIPTION
Support importing the fees from Revolut.

Based on https://github.com/tarioch/beancounttools/pull/105 by @Dr-Nuke 

Status:

- [x] Passes the pre-commit in my local setup.
- [ ] Create tests for it. I don't know what's the best way to write tests here. Maybe you could please guide me?
- [x] Not breaking compatibility: The parameter is optional. Old clients should still work
- [ ] Not breaking `smart_importer`. See below

# Usage

When creating the Revolut Importer, pass an optional parameter `fee`:

```python3
revolut_importer = revolutimp.Importer(
  "data/revolut.*.csv",
  "Assets:Revolut:EUR", 
  "EUR", 
  fee={'account': "Expenses:Revolut:Fees"} # new attribute
)
CONFIG = [revolut_importer]
```

# Smart Importer,

As discussed in https://github.com/tarioch/beancounttools/pull/105, when the transaction has more than one posting, smart import won't work anymore.

Proposed workflow:

1. Would it be possible to import once, without `fee`; then apply smart import.
2. Then import again, with `fee`
3. Then merge the transactions, given that:
  - The exports will be usually small (~10-100 entries)
  - The order is respected, hence the merge can be `O(n)`, where `n` is the number of entries on the CSV file.

If you would be so kind to guide me along those lines, I'll be happy to implement such workflow.