### PR TITLE
Awardwallet importer

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -467,7 +467,7 @@ Note that not all providers support retrieval of transaction history.
 
 .. code-block:: console
 
-  awardwallet-conf --api-key YOUR_API_KEY generate
+  awardwallet-conf --api-key YOUR_API_KEY generate > awardwallet.yaml
 
 Example configuration file:
 

--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -443,3 +443,52 @@ Import PDF from `radicant <https://radicant.com/>`__
   from tariochbctools.importers.radicant import importer as radicant
 
   CONFIG = [radicant.Importer("Account.*\.pdf", "Assets:Radicant")]
+
+AwardWallet
+------------------------------
+
+Import from `AwardWallet <https://awardwallet.com/>`__ using their `Account Access API <https://awardwallet.com/api/account>`__.
+
+As of 2025 AwardWallet integrates over 460 airline, hotel, shopping and other loyalty programmes.
+
+Follow the instructions in the `API documentation <https://awardwallet.com/api/account#introduction>`__ to register for a free Business account and create an API key.
+
+The API key is restricted to the **allowed IP addresses** you specify in the Business interface API Settings.
+
+Link and authorize personal accounts using the included ``awardwallet-conf`` CLI tool:
+
+.. code-block:: console
+
+  awardwallet-conf --api-key YOUR_API_KEY get_link_url
+
+
+Generate a config file for all linked users called (or ending with) ``awardwallet.yaml`` in your import location (e.g. download folder) and edit it to your needs.
+Note that not all providers support retrieval of transaction history.
+
+.. code-block:: console
+
+  awardwallet-conf --api-key YOUR_API_KEY generate
+
+Example configuration file:
+
+.. code-block:: yaml
+
+  api_key: YOUR_API_KEY
+  users:
+    12345:
+      name: John Smith
+      all_history: false
+      accounts:
+        7654321:
+          provider: "British Airways Club"
+          account: Assets:Current:Points
+          currency: AVIOS
+
+
+Finally, initialize the importer:
+
+.. code-block:: python
+
+  from tariochbctools.importers.awardwalletimp import importer as awimp
+
+  CONFIG = [awimp.Importer()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ testing =
 #     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
 console_scripts =
     nordigen-conf = tariochbctools.importers.nordigen.nordigen_config:run
-    awardwallet-conf = tariochbctools.importers.awardwallet.awardwallet_config:run
+    awardwallet-conf = tariochbctools.importers.awardwalletimp.config:run
 
 [test]
 # py.test options when running `python setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ package_dir =
 # install_requires = numpy; scipy
 install_requires =
     importlib-metadata; python_version<"3.8"
+    awardwallet @ git+https://github.com/markferry/awardwallet.git
     beancount>=3
     beangulp
     beanprice
@@ -87,6 +88,7 @@ testing =
 #     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
 console_scripts =
     nordigen-conf = tariochbctools.importers.nordigen.nordigen_config:run
+    awardwallet-conf = tariochbctools.importers.awardwallet.awardwallet_config:run
 
 [test]
 # py.test options when running `python setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ package_dir =
 # install_requires = numpy; scipy
 install_requires =
     importlib-metadata; python_version<"3.8"
-    awardwallet @ git+https://github.com/markferry/awardwallet.git
+    awardwallet
     beancount>=3
     beangulp
     beanprice

--- a/src/tariochbctools/importers/awardwallet/awardwallet_config.py
+++ b/src/tariochbctools/importers/awardwallet/awardwallet_config.py
@@ -1,0 +1,134 @@
+import argparse
+import json
+import sys
+import uuid
+from typing import Any
+
+import yaml
+from awardwallet.api import (
+    AccessLevel,
+    AwardWalletAPI,
+    ProviderKind,
+)
+
+
+def list_users(client):
+    connected_users = client.list_connected_users()
+    users = {}
+    for user in connected_users:
+        users[user["userId"]] = user["userName"]
+
+    yaml.dump(users, sys.stdout, sort_keys=False)
+
+
+def account_details(client, account_id):
+    account_details = client.get_account_details(account_id)
+    print(json.dumps(account_details, indent=2))  # noqa: T201
+
+
+def get_link_url(client):
+    connection_url = client.get_get_link_url(
+        platform="desktop",
+        access_level=AccessLevel.READ_ALL_EXCEPT_PASSWORDS,
+        state=str(uuid.uuid4()),
+    )
+    print(  # noqa: T201
+        "Redirect your user to this URL to authorize the connection (expires in 10 minutes):"
+    )
+    print(connection_url)  # noqa: T201
+
+
+def generate(client):
+    """
+    Generate a config for a user including user_id and account_id list.
+    Output in yaml format.
+    """
+    config = {}
+    config["api_key"] = client.api_key
+    config["users"] = {}
+
+    connected_users = client.list_connected_users()
+
+    for user in connected_users:
+        user_id = user["userId"]
+        user_details = client.get_connected_user_details(user_id)
+        account_config = {}
+
+        for account in user_details.get("accounts", []):
+            account_config[account["accountId"]] = {
+                "provider": account["displayName"],
+                "account": "Assets:Current:Points",  # Placeholder, user should adjust
+                "currency": "POINTS",
+            }
+
+        config["users"][user_id] = {
+            "name": user["userName"],
+            "accounts": account_config,
+        }
+
+    yaml.dump(config, sys.stdout, sort_keys=False)
+
+
+def list_providers(client):
+    providers = client.list_providers()
+
+    providers_filtered = {
+        p["code"]: {
+            "displayName": p["displayName"],
+            "kind": ProviderKind(p["kind"]).name,
+        }
+        for p in sorted(providers, key=lambda d: d["displayName"])
+    }
+
+    yaml.dump(providers_filtered, sys.stdout, sort_keys=False, allow_unicode=True)
+
+
+def parse_args(args: Any) -> Any:
+    parser = argparse.ArgumentParser(description="awardwallet-config")
+    parser.add_argument(
+        "--api-key",
+        required=True,
+        help="API key, can be generated on AwardWallet Business interface",
+    )
+    parser.add_argument(
+        "--account-id",
+        required=False,
+        help="Account ID for account-specific operations",
+    )
+    parser.add_argument(
+        "mode",
+        choices=[
+            "get_link_url",
+            "generate",
+            "list_providers",
+            "list_users",
+            "account_details",
+        ],
+    )
+    return parser.parse_args(args)
+
+
+def main(args: Any) -> None:
+    args = parse_args(args)
+
+    client = AwardWalletAPI(args.api_key)
+
+    if args.mode == "get_link_url":
+        get_link_url(client)
+    elif args.mode == "generate":
+        generate(client)
+    elif args.mode == "list_providers":
+        list_providers(client)
+    elif args.mode == "list_users":
+        list_users(client)
+    elif args.mode == "account_details":
+        account_details(client, args.account_id)
+
+
+def run() -> None:
+    """Entry point for console_scripts"""
+    main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/tariochbctools/importers/awardwallet/importer.py
+++ b/src/tariochbctools/importers/awardwallet/importer.py
@@ -1,0 +1,88 @@
+from os import path
+from typing import Any
+
+import beangulp
+import dateutil.parser
+import yaml
+from awardwallet.api import AwardWalletAPI
+from beancount.core import amount, data
+from beancount.core.number import D
+
+
+class Importer(beangulp.Importer):
+    """An importer for AwardWallet"""
+
+    def _configure(self, filepath: str, existing: data.Entries) -> None:
+        with open(filepath, "r") as f:
+            self.config = yaml.safe_load(f)
+        self.api_key = self.config["api_key"]
+
+    def identify(self, filepath: str) -> bool:
+        return path.basename(filepath).endswith("awardwallet.yaml")
+
+    def account(self, filepath: str) -> data.Account:
+        return ""
+
+    def extract(self, filepath: str, existing: data.Entries = None) -> data.Entries:
+        self._configure(filepath, existing)
+        client = AwardWalletAPI(self.api_key)
+        entries = []
+
+        for user_id, user in self.config["users"].items():
+            user_details = client.get_connected_user_details(user_id)
+            entries.extend(self._extract_account(user, user_details))
+
+    def _extract_account(self, user: dict, user_details: dict) -> data.Account:
+        entries = []
+        for account in user_details["accounts"]:
+            if account["accountId"] in user["accounts"]:
+                account_config = user["accounts"][account["accountId"]]
+                for trx in account["history"]:
+                    local_account = account_config["account"]
+                    currency = account_config["currency"]
+
+                    entries.extend(
+                        self._extract_transaction(trx, local_account, currency)
+                    )
+        return entries
+
+    def _extract_transaction(
+        self,
+        trx: dict[str, Any],
+        local_account: data.Account,
+        currency: str,
+    ) -> data.Transaction:
+        entries = []
+        trx_date = None
+        trx_description = None
+        trx_amount = None
+
+        for f in trx.get("fields", []):
+            if f["code"] == "PostingDate":
+                trx_date = dateutil.parser.parse(f["value"]).date()
+            if f["code"] == "Description":
+                trx_description = f["value"]
+            if f["code"] == "Miles":
+                trx_amount = D(f["value"])
+
+        entry = data.Transaction(
+            {},
+            trx_date,
+            "*",
+            "",
+            trx_description,
+            data.EMPTY_SET,
+            data.EMPTY_SET,
+            [
+                data.Posting(
+                    local_account,
+                    amount.Amount(trx_amount, currency),
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        entries.append(entry)
+        return entries

--- a/src/tariochbctools/importers/awardwalletimp/config.py
+++ b/src/tariochbctools/importers/awardwalletimp/config.py
@@ -27,7 +27,7 @@ def account_details(client, account_id):
 
 
 def get_link_url(client):
-    connection_url = client.get_get_link_url(
+    connection_url = client.get_connection_link(
         platform="desktop",
         access_level=AccessLevel.READ_ALL_EXCEPT_PASSWORDS,
         state=str(uuid.uuid4()),
@@ -63,6 +63,7 @@ def generate(client):
 
         config["users"][user_id] = {
             "name": user["userName"],
+            "all_history": False,
             "accounts": account_config,
         }
 

--- a/src/tariochbctools/importers/awardwalletimp/importer.py
+++ b/src/tariochbctools/importers/awardwalletimp/importer.py
@@ -1,3 +1,4 @@
+import logging
 from os import path
 from typing import Any
 
@@ -44,6 +45,8 @@ class Importer(beangulp.Importer):
                     entries.extend(
                         self._extract_transaction(trx, local_account, currency)
                     )
+            else:
+                logging.warning("Ignoring account ID %s", account["accountId"])
         return entries
 
     def _extract_transaction(
@@ -59,11 +62,11 @@ class Importer(beangulp.Importer):
 
         for f in trx.get("fields", []):
             if f["code"] == "PostingDate":
-                trx_date = dateutil.parser.parse(f["value"]).date()
+                trx_date = dateutil.parser.parse(f["value"]["value"]).date()
             if f["code"] == "Description":
-                trx_description = f["value"]
+                trx_description = f["value"]["value"]
             if f["code"] == "Miles":
-                trx_amount = D(f["value"])
+                trx_amount = D(f["value"]["value"])
 
         entry = data.Transaction(
             {},

--- a/src/tariochbctools/importers/awardwalletimp/importer.py
+++ b/src/tariochbctools/importers/awardwalletimp/importer.py
@@ -5,7 +5,7 @@ from typing import Any
 import beangulp
 import dateutil.parser
 import yaml
-from awardwallet.api import AwardWalletAPI
+from awardwallet import AwardWalletClient
 from beancount.core import amount, data
 from beancount.core.number import D
 
@@ -26,7 +26,7 @@ class Importer(beangulp.Importer):
 
     def extract(self, filepath: str, existing: data.Entries = None) -> data.Entries:
         self._configure(filepath, existing)
-        client = AwardWalletAPI(self.api_key)
+        client = AwardWalletClient(self.api_key)
         entries = []
 
         for user_id, user in self.config["users"].items():
@@ -71,7 +71,7 @@ class Importer(beangulp.Importer):
         return entries
 
     def _extract_account_history(
-        self, user: dict, client: AwardWalletAPI
+        self, user: dict, client: AwardWalletClient
     ) -> list[data.Transaction]:
         entries = []
         for account_id, account_config in user["accounts"].items():

--- a/tests/tariochbctools/importers/test_awardwallet.py
+++ b/tests/tariochbctools/importers/test_awardwallet.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from beancount.core.number import D
 
-from tariochbctools.importers.awardwallet import importer as awimp
+from tariochbctools.importers.awardwalletimp import importer as awimp
 
 # pylint: disable=protected-access
 
@@ -25,22 +25,22 @@ TEST_TRX = b"""
         {
           "name": "Transaction Date",
           "code": "PostingDate",
-          "value": "9/30/12"
+          "value": {"value": "9/30/12", "type": "string"}
         },
         {
           "name": "Description",
           "code": "Description",
-          "value": "Expired Points"
+          "value": {"value": "Expired Points", "type": "string"}
         },
         {
           "name": "Type",
           "code": "Info",
-          "value": "Adjustments"
+          "value": {"value": "Adjustments", "type": "string"}
         },
         {
           "name": "Points",
           "code": "Miles",
-          "value": "-1,042"
+          "value": {"value": "-1,042", "type": "miles"}
         }
       ]
     }
@@ -83,49 +83,49 @@ TEST_USER_DETAILS = b"""
           "properties": [
             {
               "name": "Next Elite Level",
-              "value": "Bronze",
+              "value": {"value": "Bronze", "type": "string"},
               "kind": 9
             },
             {
               "name": "Date of joining the club",
-              "value": "20 Jun 2013",
+              "value": {"value": "20 Jun 2013", "type": "string"},
               "kind": 5
             },
             {
               "name": "Lifetime Tier Points",
-              "value": "35,000"
+              "value": {"value": "35,000", "type": "string"}
             },
             {
               "name": "Executive Club Tier Points",
-              "value": "35,000"
+              "value": {"value": "35,000", "type": "string"}
             },
             {
               "name": "Card expiry date",
-              "value": "31 Mar 2017"
+              "value": {"value": "31 Mar 2017", "type": "string"}
             },
             {
               "name": "Membership year ends",
-              "value": "08 Feb 2016"
+              "value": {"value": "08 Feb 2016", "type": "string"}
             },
             {
               "name": "Last Activity",
-              "value": "10-Dec-15",
+              "value": {"value": "10-Dec-15", "type": "string"},
               "kind": 13
             },
             {
               "name": "Name",
-              "value": "Mr Smith",
+              "value": {"value": "Mr Smith", "type": "string"},
               "kind": 12
             },
             {
               "name": "Level",
-              "value": "Blue",
+              "value": {"value": "Blue", "type": "string"},
               "rank": 0,
               "kind": 3
             },
             {
               "name": "Membership no",
-              "value": "1122334455",
+              "value": {"value": "1122334455", "type": "string"},
               "kind": 1
             }
           ],
@@ -135,22 +135,22 @@ TEST_USER_DETAILS = b"""
                 {
                   "name": "Transaction Date",
                   "code": "PostingDate",
-                  "value": "3/31/14"
+                  "value": {"value": "3/31/14", "type": "string"}
                 },
                 {
                   "name": "Description",
                   "code": "Description",
-                  "value": "Expired Points"
+                  "value": {"value": "Expired Points", "type": "string"}
                 },
                 {
                   "name": "Type",
                   "code": "Info",
-                  "value": "Adjustments"
+                  "value": {"value": "Adjustments", "type": "string"}
                 },
                 {
                   "name": "Points",
                   "code": "Miles",
-                  "value": "-100"
+                  "value": {"value": "-100", "type": "miles"}
                 }
               ]
             },
@@ -159,22 +159,22 @@ TEST_USER_DETAILS = b"""
                 {
                   "name": "Transaction Date",
                   "code": "PostingDate",
-                  "value": "12/11/13"
+                  "value": {"value": "12/11/13", "type": "string"}
                 },
                 {
                   "name": "Description",
                   "code": "Description",
-                  "value": "Google Wallet"
+                  "value": {"value": "Google Wallet", "type": "string"}
                 },
                 {
                   "name": "Type",
                   "code": "Info",
-                  "value": "Other Earning"
+                  "value": {"value": "Other Earning", "type": "string"}
                 },
                 {
                   "name": "Points",
                   "code": "Miles",
-                  "value": "+100"
+                  "value": {"value": "+100", "type": "miles"}
                 }
               ]
             },
@@ -183,22 +183,22 @@ TEST_USER_DETAILS = b"""
                 {
                   "name": "Transaction Date",
                   "code": "PostingDate",
-                  "value": "9/30/12"
+                  "value": {"value": "9/30/12", "type": "string"}
                 },
                 {
                   "name": "Description",
                   "code": "Description",
-                  "value": "Expired Points"
+                  "value": {"value": "Expired Points", "type": "string"}
                 },
                 {
                   "name": "Type",
                   "code": "Info",
-                  "value": "Adjustments"
+                  "value": {"value": "Adjustments", "type": "string"}
                 },
                 {
                   "name": "Points",
                   "code": "Miles",
-                  "value": "-1,042"
+                  "value": {"value": "-1,042", "type": "miles"}
                 }
               ]
             }
@@ -246,7 +246,7 @@ def tmp_trx_fixture():
 
 @pytest.fixture(name="tmp_user_details")
 def tmp_user_details_fixture():
-    yield json.loads(TEST_USER_DETAILS)
+    yield json.loads(TEST_USER_DETAILS, strict=False)
 
 
 def test_identify(importer, tmp_config):
@@ -255,7 +255,9 @@ def test_identify(importer, tmp_config):
 
 def test_extract_transaction_simple(importer, tmp_trx):
     entries = importer._extract_transaction(tmp_trx, "Assets:Other", "POINTS")
-    assert entries[0].postings[0].units.number == D(tmp_trx["fields"][3]["value"])
+    assert entries[0].postings[0].units.number == D(
+        tmp_trx["fields"][3]["value"]["value"]
+    )
 
 
 def test_extract_account(importer, tmp_user_details):

--- a/tests/tariochbctools/importers/test_awardwallet.py
+++ b/tests/tariochbctools/importers/test_awardwallet.py
@@ -298,7 +298,7 @@ def test_extract_user_history(importer, tmp_user_details):
     assert len(entries) == 3
 
 
-@patch("tariochbctools.importers.awardwalletimp.importer.AwardWalletAPI")
+@patch("tariochbctools.importers.awardwalletimp.importer.AwardWalletClient")
 def test_extract_all_users(mock_api, importer, tmp_config, tmp_user_details):
     importer._extract_user_history = MagicMock()
 
@@ -306,7 +306,7 @@ def test_extract_all_users(mock_api, importer, tmp_config, tmp_user_details):
     assert importer._extract_user_history.call_count == 2
 
 
-@patch("tariochbctools.importers.awardwalletimp.importer.AwardWalletAPI")
+@patch("tariochbctools.importers.awardwalletimp.importer.AwardWalletClient")
 def test_extract_all_accounts(mock_api, importer, tmp_config, tmp_user_details):
     importer._extract_transactions = MagicMock()
     mock_api.return_value.get_connected_user_details.return_value = tmp_user_details

--- a/tests/tariochbctools/importers/test_awardwallet.py
+++ b/tests/tariochbctools/importers/test_awardwallet.py
@@ -12,6 +12,7 @@ TEST_CONFIG = b"""
     users:
       12345:
         name: John Smith
+        all_history: false
         accounts:
           7654321:
             provider: "British Airways Club"
@@ -254,15 +255,15 @@ def test_identify(importer, tmp_config):
 
 
 def test_extract_transaction_simple(importer, tmp_trx):
-    entries = importer._extract_transaction(tmp_trx, "Assets:Other", "POINTS")
+    entries = importer._extract_transaction(tmp_trx, "Assets:Other", "POINTS", 7654321)
     assert entries[0].postings[0].units.number == D(
         tmp_trx["fields"][3]["value"]["value"]
     )
 
 
-def test_extract_account(importer, tmp_user_details):
-    entries = importer._extract_account(
+def test_extract_user_history(importer, tmp_user_details):
+    entries = importer._extract_user_history(
         importer.config["users"][12345],
         tmp_user_details,
     )
-    assert entries
+    assert len(entries) == 3

--- a/tests/tariochbctools/importers/test_awardwallet.py
+++ b/tests/tariochbctools/importers/test_awardwallet.py
@@ -1,0 +1,266 @@
+import json
+
+import pytest
+from beancount.core.number import D
+
+from tariochbctools.importers.awardwallet import importer as awimp
+
+# pylint: disable=protected-access
+
+TEST_CONFIG = b"""
+    api_key: deadc0dedeadc0dedeadc0dedeadc0de
+    users:
+      12345:
+        name: John Smith
+        accounts:
+          7654321:
+            provider: "British Airways Club"
+            account: Assets:Current:Points
+            currency: AVIOS
+"""
+
+TEST_TRX = b"""
+    {
+      "fields": [
+        {
+          "name": "Transaction Date",
+          "code": "PostingDate",
+          "value": "9/30/12"
+        },
+        {
+          "name": "Description",
+          "code": "Description",
+          "value": "Expired Points"
+        },
+        {
+          "name": "Type",
+          "code": "Info",
+          "value": "Adjustments"
+        },
+        {
+          "name": "Points",
+          "code": "Miles",
+          "value": "-1,042"
+        }
+      ]
+    }
+"""
+
+TEST_USER_DETAILS = b"""
+    {
+      "userId": 12345,
+      "fullName": "John Smith",
+      "status": "Free",
+      "userName": "JSmith",
+      "email": "JSmith@email.com",
+      "forwardingEmail": "JSmith@AwardWallet.com",
+      "accessLevel": "Regular",
+      "connectionType": "Connected",
+      "accountsAccessLevel": "Full control",
+      "accountsSharedByDefault": true,
+      "editConnectionUrl": "https://business.awardwallet.com/members/connection/112233",
+      "accountListUrl": "https://business.awardwallet.com/account/list#/?agentId=112233",
+      "timelineUrl": "https://business.awardwallet.com/timeline/?agentId=166765#/112233",
+      "bookingRequestsUrl": "https://business.awardwallet.com/awardBooking/queue?user_filter=332211",
+      "accounts": [
+        {
+          "accountId": 7654321,
+          "code": "british",
+          "displayName": "British Airways (Executive Club)",
+          "kind": "Airlines",
+          "login": "johnsmith",
+          "autologinUrl": "https://business.awardwallet.com/account/redirect?ID=7654321",
+          "updateUrl": "https://business.awardwallet.com/account/edit/7654321?autosubmit=1",
+          "editUrl": "https://business.awardwallet.com/account/edit/7654321",
+          "balance": "146,780",
+          "balanceRaw": 146780,
+          "owner": "John Smith",
+          "errorCode": 1,
+          "lastDetectedChange": "+750",
+          "expirationDate": "2018-12-10T00:00:00+00:00",
+          "lastRetrieveDate": "2016-01-15T00:00:00+00:00",
+          "lastChangeDate": "2016-01-15T00:49:33+00:00",
+          "properties": [
+            {
+              "name": "Next Elite Level",
+              "value": "Bronze",
+              "kind": 9
+            },
+            {
+              "name": "Date of joining the club",
+              "value": "20 Jun 2013",
+              "kind": 5
+            },
+            {
+              "name": "Lifetime Tier Points",
+              "value": "35,000"
+            },
+            {
+              "name": "Executive Club Tier Points",
+              "value": "35,000"
+            },
+            {
+              "name": "Card expiry date",
+              "value": "31 Mar 2017"
+            },
+            {
+              "name": "Membership year ends",
+              "value": "08 Feb 2016"
+            },
+            {
+              "name": "Last Activity",
+              "value": "10-Dec-15",
+              "kind": 13
+            },
+            {
+              "name": "Name",
+              "value": "Mr Smith",
+              "kind": 12
+            },
+            {
+              "name": "Level",
+              "value": "Blue",
+              "rank": 0,
+              "kind": 3
+            },
+            {
+              "name": "Membership no",
+              "value": "1122334455",
+              "kind": 1
+            }
+          ],
+          "history": [
+            {
+              "fields": [
+                {
+                  "name": "Transaction Date",
+                  "code": "PostingDate",
+                  "value": "3/31/14"
+                },
+                {
+                  "name": "Description",
+                  "code": "Description",
+                  "value": "Expired Points"
+                },
+                {
+                  "name": "Type",
+                  "code": "Info",
+                  "value": "Adjustments"
+                },
+                {
+                  "name": "Points",
+                  "code": "Miles",
+                  "value": "-100"
+                }
+              ]
+            },
+            {
+              "fields": [
+                {
+                  "name": "Transaction Date",
+                  "code": "PostingDate",
+                  "value": "12/11/13"
+                },
+                {
+                  "name": "Description",
+                  "code": "Description",
+                  "value": "Google Wallet"
+                },
+                {
+                  "name": "Type",
+                  "code": "Info",
+                  "value": "Other Earning"
+                },
+                {
+                  "name": "Points",
+                  "code": "Miles",
+                  "value": "+100"
+                }
+              ]
+            },
+            {
+              "fields": [
+                {
+                  "name": "Transaction Date",
+                  "code": "PostingDate",
+                  "value": "9/30/12"
+                },
+                {
+                  "name": "Description",
+                  "code": "Description",
+                  "value": "Expired Points"
+                },
+                {
+                  "name": "Type",
+                  "code": "Info",
+                  "value": "Adjustments"
+                },
+                {
+                  "name": "Points",
+                  "code": "Miles",
+                  "value": "-1,042"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+"""
+
+
+@pytest.fixture(name="tmp_config")
+def tmp_config_fixture(tmp_path):
+    config = tmp_path / "awardwallet.yaml"
+    config.write_bytes(TEST_CONFIG)
+    yield config
+
+
+@pytest.fixture(name="importer")
+def awardwallet_importer_fixture(tmp_config):
+    importer = awimp.Importer()
+    importer._configure(tmp_config, [])
+    yield importer
+
+
+@pytest.fixture(name="importer_factory")
+def awardwallet_importer_factory(tmp_path):
+    """A awardwallet importer factory for
+    generating an importer with a custom config
+    """
+
+    def _importer_with_config(custom_config):
+        config = tmp_path / "awardwallet.yaml"
+        config.write_bytes(custom_config)
+        importer = awimp.Importer()
+        importer._configure(config, [])
+        return importer
+
+    yield _importer_with_config
+
+
+@pytest.fixture(name="tmp_trx")
+def tmp_trx_fixture():
+    yield json.loads(TEST_TRX)
+
+
+@pytest.fixture(name="tmp_user_details")
+def tmp_user_details_fixture():
+    yield json.loads(TEST_USER_DETAILS)
+
+
+def test_identify(importer, tmp_config):
+    assert importer.identify(tmp_config)
+
+
+def test_extract_transaction_simple(importer, tmp_trx):
+    entries = importer._extract_transaction(tmp_trx, "Assets:Other", "POINTS")
+    assert entries[0].postings[0].units.number == D(tmp_trx["fields"][3]["value"])
+
+
+def test_extract_account(importer, tmp_user_details):
+    entries = importer._extract_account(
+        importer.config["users"][12345],
+        tmp_user_details,
+    )
+    assert entries


### PR DESCRIPTION
Import loyalty programme transactions from [AwardWallet](https://awardwallet.com/) using their [Account Access API](https://awardwallet.com/api/account).

As of 2025 AwardWallet integrates over 460 airline, hotel, shopping and other loyalty programmes.

Included `awardwallet-conf` CLI tool:

``` console
awardwallet-conf --api-key YOUR_API_KEY get_link_url
```

Generate a config file for all linked users:

``` console
awardwallet-conf --api-key YOUR_API_KEY generate > awardwallet.yaml
```

Example configuration file:

``` yaml
api_key: YOUR_API_KEY
users:
  12345:
    name: John Smith
    all_history: false
    accounts:
      7654321:
        provider: "British Airways Club"
        account: Assets:Current:Points
        currency: AVIOS
```

Example (real) transaction:

```beancount
2023-04-06 * "KL Flight Redemption -Booking Ref EACM7S ,PAX ,CPT-AMS"
  account-id: "3150372"
  tier-points: "0"
  Assets:Current:Points  -71000 VIRGINPTS
  Expenses:Travel:Transport
```

Doesn't (yet) generate balance entries.
