### PR TITLE
truelayer: better balances

### DIFF
--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -159,7 +159,7 @@ class Importer(beangulp.Importer):
         invert_sign: bool,
     ) -> data.Transaction:
         entries = []
-        metakv = {}
+        metakv: dict[str, Any] = {}
 
         id_meta_kvs = {
             k: trx["meta"][k] for k in TX_OPTIONAL_META_ID_FIELDS if trx["meta"].get(k)
@@ -247,8 +247,7 @@ class Importer(beangulp.Importer):
     ) -> data.Transaction:
         entries = []
 
-        metakv = {}
-        meta = data.new_metadata("", 0, metakv)
+        meta = data.new_metadata("", 0)
 
         balance = D(str(result["current"]))
         signed_balance = -1 * balance if invert_sign else balance

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -206,39 +206,6 @@ class Importer(beangulp.Importer):
         )
         entries.append(entry)
 
-        if trx["transaction_id"] == transactions[-1]["transaction_id"]:
-            balDate = trxDate + timedelta(days=1)
-            metakv = {}
-            if self.existing is not None:
-                for exEntry in self.existing:
-                    if (
-                        isinstance(exEntry, data.Balance)
-                        and exEntry.date == balDate
-                        and exEntry.account == local_account
-                    ):
-                        metakv["__duplicate__"] = True
-
-            meta = data.new_metadata("", 0, metakv)
-
-            # Only if the 'balance' permission is present
-            if "running_balance" in trx:
-                tx_balance = D(str(trx["running_balance"]["amount"]))
-                # avoid pylint invalid-unary-operand-type
-                signed_balance = -1 * tx_balance if invert_sign else tx_balance
-
-                entries.append(
-                    data.Balance(
-                        meta,
-                        balDate,
-                        local_account,
-                        amount.Amount(
-                            signed_balance, trx["running_balance"]["currency"]
-                        ),
-                        None,
-                        None,
-                    )
-                )
-
         return entries
 
     def _extract_balance(
@@ -252,6 +219,7 @@ class Importer(beangulp.Importer):
         meta = data.new_metadata("", 0)
 
         balance = D(str(result["current"]))
+        # avoid pylint invalid-unary-operand-type
         signed_balance = -1 * balance if invert_sign else balance
         balance_date = dateutil.parser.parse(result["update_timestamp"]).date()
 

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -10,6 +10,8 @@ import yaml
 from beancount.core import amount, data
 from beancount.core.number import D
 
+from tariochbctools.importers.general.deduplication import ReferenceDuplicatesComparator
+
 # https://docs.truelayer.com/#retrieve-account-transactions
 
 TX_MANDATORY_ID_FIELDS = ("transaction_id",)
@@ -283,3 +285,5 @@ class Importer(beangulp.Importer):
             )
 
         return entries
+
+    cmp = ReferenceDuplicatesComparator(TX_MANDATORY_ID_FIELDS)

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -258,7 +258,7 @@ class Importer(beangulp.Importer):
         entries.append(
             data.Balance(
                 meta,
-                balance_date,
+                balance_date + timedelta(days=1),
                 local_account,
                 amount.Amount(signed_balance, result["currency"]),
                 None,

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 import dateutil.parser
 import pytest
@@ -162,9 +163,9 @@ def test_extract_balance(importer, tmp_trx):
     assert len(entries) == 1
     assert entries[-1].amount.number == D(str(tmp_balance["current"]))
     assert (
-        entries[-1].date
+        entries[-1].date - timedelta(days=1)
         == dateutil.parser.parse(tmp_balance["update_timestamp"]).date()
-    )
+    ), "balance date should be one day after update_timestamp"
 
 
 def test_extract_statement_balance(importer, tmp_trx):

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -138,15 +138,6 @@ def test_extract_transaction_simple(importer, tmp_trx):
     assert entries[0].postings[0].units.number == D(str(tmp_trx["amount"]))
 
 
-def test_extract_transaction_with_balance(importer, tmp_trx):
-    entries = importer._extract_transaction(
-        tmp_trx, "Assets:Other", [tmp_trx], invert_sign=False
-    )
-    # one entry, one balance
-    assert len(entries) == 2
-    assert entries[1].amount.number == D(str(tmp_trx["running_balance"]["amount"]))
-
-
 def test_extract_transaction_invert_sign(importer, tmp_trx):
     """Show that sign inversion works"""
     entries = importer._extract_transaction(


### PR DESCRIPTION
Make an explicit balance request for each account instead of relying on optional "running_balance" within transactions.

Now generates ~~up to three~~ one or two balances:

 - current balance (always present)
 - statement balance (optional, in balance)
 - ~~running balance (optional, in transactions)~~

