### PR TITLE
fix #83: postfinance dateutil.parser

### DIFF
--- a/src/tariochbctools/importers/postfinance/importer.py
+++ b/src/tariochbctools/importers/postfinance/importer.py
@@ -1,10 +1,11 @@
 import csv
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 
 import beangulp
+import dateutil.parser
 from beancount.core import data
 
 
@@ -31,7 +32,7 @@ class Importer(beangulp.Importer):
         for row in reader:
             try:
                 book_date_str, text, credit, debit, val_date, balance_str = tuple(row)
-                book_date = datetime.strptime(book_date_str, "%Y-%m-%d").date()
+                book_date = dateutil.parser.parse(book_date_str).date()
                 if credit:
                     amount = data.Amount(Decimal(credit), self.currency)
                 elif debit:

--- a/tests/tariochbctools/importers/test_postfinance.py
+++ b/tests/tariochbctools/importers/test_postfinance.py
@@ -1,0 +1,46 @@
+import pytest
+from beancount.core.amount import Amount
+from beancount.core.number import D
+
+from tariochbctools.importers.postfinance import importer as pfimp
+
+TEST_CSV = """
+Booking date;Notification text;Credit in CHF;Debit in CHF;Value;Balance in CHF
+31.12.2022;"Preis für Bankpaket Smart";;-5;31.12.2022;7881.98
+"""
+
+TEST_CSV_2021 = """
+Booking date;Notification text;Credit in CHF;Debit in CHF;Value;Balance in CHF
+2022-12-31;"Preis für Bankpaket Smart";;-5;2022-12-31;7881.98
+"""
+
+
+@pytest.fixture(name="importer")
+def importer_fixture():
+    importer = pfimp.Importer(".*.csv", "Assets:PostFinance:CHF")
+    yield importer
+
+
+@pytest.fixture
+def tmp_csv(tmp_path, request):
+    csv = tmp_path / "test.csv"
+    csv.write_text(request.param)
+    yield csv
+
+
+@pytest.mark.parametrize("tmp_csv", [TEST_CSV], indirect=True)
+def test_identify(importer, tmp_csv):
+    assert importer.identify(str(tmp_csv))
+
+
+@pytest.mark.parametrize(
+    "tmp_csv",
+    (TEST_CSV, TEST_CSV_2021),
+    ids=("dd.mm.yyyy", "yyyy-mm-dd"),
+    indirect=True,
+)
+def test_extract(importer, tmp_csv):
+    entries = importer.extract(str(tmp_csv), [])
+    assert entries
+    assert entries[0].postings[-1].units == Amount(D(-5), "CHF")
+    assert entries[0].date.year == 2022


### PR DESCRIPTION
Use dateutil.parser to support both `yyyy-mm-dd` and `dd.mm.yyyy` formats.

Fixes #83. 