### PR TITLE
Fix: Strip newlines from MT940 payees and narrations

### DIFF
--- a/src/tariochbctools/importers/general/mt940importer.py
+++ b/src/tariochbctools/importers/general/mt940importer.py
@@ -37,12 +37,20 @@ class Importer(beangulp.Importer):
                 date = trxdata["entry_date"]
             else:
                 date = trxdata["date"]
+            payee = self.prepare_payee(trxdata)
+            if payee:
+                payee = re.sub(r'\s+', ' ', payee.strip())
+            
+            narration = self.prepare_narration(trxdata)
+            if narration:
+                narration = re.sub(r'\s+', ' ', narration.strip())
+
             entry = data.Transaction(
                 meta,
                 date,
                 "*",
-                self.prepare_payee(trxdata),
-                self.prepare_narration(trxdata),
+                payee,
+                narration,
                 data.EMPTY_SET,
                 data.EMPTY_SET,
                 [

--- a/src/tariochbctools/importers/general/mt940importer.py
+++ b/src/tariochbctools/importers/general/mt940importer.py
@@ -39,11 +39,11 @@ class Importer(beangulp.Importer):
                 date = trxdata["date"]
             payee = self.prepare_payee(trxdata)
             if payee:
-                payee = re.sub(r'\s+', ' ', payee.strip())
-            
+                payee = re.sub(r"\s+", " ", payee.strip())
+
             narration = self.prepare_narration(trxdata)
             if narration:
-                narration = re.sub(r'\s+', ' ', narration.strip())
+                narration = re.sub(r"\s+", " ", narration.strip())
 
             entry = data.Transaction(
                 meta,

--- a/tests/tariochbctools/importers/test_mt940importer.py
+++ b/tests/tariochbctools/importers/test_mt940importer.py
@@ -1,0 +1,40 @@
+import datetime
+from collections import namedtuple
+from unittest.mock import patch
+
+import pytest
+
+from tariochbctools.importers.general import mt940importer
+
+MockAmount = namedtuple("MockAmount", ["amount", "currency"])
+
+
+class MockTrx:
+    def __init__(self):
+        self.data = {
+            "bank_reference": "ref123",
+            "date": datetime.date(2021, 6, 14),
+            "amount": MockAmount("20.5", "CHF"),
+            "transaction_details": "DETAIL \nLINE",
+            "extra_details": "EXTRA \nLINE",
+        }
+
+
+@pytest.fixture(name="importer")
+def importer_fixture():
+    return mt940importer.Importer(".*\\.mt940", "Assets:Bank:CHF")
+
+
+def test_extract_removes_newlines(importer):
+    mock_trx = MockTrx()
+    with patch("mt940.parse", return_value=[mock_trx]):
+        entries = importer.extract("test.mt940", [])
+        assert len(entries) == 1
+
+        entry = entries[0]
+        # Verify payee has no newlines (prepare_payee returns empty string in base class)
+        assert "\n" not in entry.payee
+
+        # Verify narration has no newlines
+        assert "\n" not in entry.narration
+        assert "DETAIL LINE EXTRA LINE" == entry.narration


### PR DESCRIPTION
When importing MT940 statements, raw fields often contain newlines which break the Beancount format. This commit sanitizes the `payee` and `narration` strings by replacing newlines with spaces and collapsing multiple consecutive spaces into a single one before the `data.Transaction` is created.