### PR TITLE
truelayer: add oama support

### DIFF
--- a/docs/importers.rst
+++ b/docs/importers.rst
@@ -140,7 +140,7 @@ fail.
 TrueLayer
 ---------
 
-Import from `TrueLayer <https://www.truelayer.com/>`__ using their api services. e.g. supports Revolut.
+Import from `TrueLayer <https://www.truelayer.com/>`__ using their API services. e.g. supports Revolut.
 You need to create a dev account and see their documentation about how to get a refresh token.
 
 .. code-block:: python
@@ -154,9 +154,12 @@ Create a file called (or ending with) truelayer.yaml in your import location (e.
 .. code-block:: yaml
 
   account: <Assets:MyBank>
+  # Option 1: direct access using client_id and client_secret and refresh_token
   client_id: <CLIENT ID>
   client_secret: <CLIENT SECRET>
   refresh_token: <REFRESH TOKEN>
+  # Option 2: access token via external command (e.g. oama)
+  auth_command: "oama access <your-account>"
 
 Instead of a single ``account``, the configuration may include a *mapping* from
 TrueLayer account IDs to beancount accounts. e.g.:
@@ -168,6 +171,52 @@ TrueLayer account IDs to beancount accounts. e.g.:
     ec34db160c61d468dc1cedde8bedb1f1: Liabilities:Visa
 
 If it is present, transactions for *only these accounts* will be imported.
+
+Authentication
+~~~~~~~~~~~~~~
+
+There are **two mechanisms** for obtaining access tokens:
+
+**1. Direct refresh token - ``refresh_token``**
+   Provide a TrueLayer refresh token directly in the config. The importer will exchange it
+   for an access token on each run.
+
+   .. code-block:: yaml
+
+     client_id: <CLIENT ID>
+     client_secret: <CLIENT SECRET>
+     refresh_token: <REFRESH TOKEN>
+
+**2. External token manager (recommended) - ``auth_command``**
+   Use a tool like `oama <https://github.com/pdobsan/oama>`__ to handle OAuth automatically.
+   oama stores refresh tokens securely and refreshes access tokens in the background.
+
+   .. code-block:: yaml
+
+     auth_command: "oama access <your-account>"
+
+   When using ``auth_command``, you can omit ``refresh_token``, ``client_id`` and ``client_secret``
+   from the config (they are stored in oama's config instead).
+
+The importer obtains an access token in this order of preference:
+
+1. ``access_token`` from the config file (static, not recommended for production)
+2. Running ``auth_command`` (shell command, should output token to stdout)
+3. Using ``refresh_token`` to obtain a new access token from TrueLayer
+
+Example ``~/.config/oama/config.yaml`` for TrueLayer:
+
+.. code-block:: yaml
+
+  services:
+    truelayer:
+      client_id: <YOUR_CLIENT_ID>
+      client_secret: <YOUR_CLIENT_SECRET>
+      auth_endpoint: https://auth.truelayer.com/
+      auth_http_method: GET
+      token_endpoint: https://auth.truelayer.com/connect/token
+      auth_scope: "info accounts balance cards transactions direct_debits standing_orders offline_access"
+      redirect_uri: http://localhost:3000/callback
 
 
 GoCardless (formerly Nordigen)

--- a/src/tariochbctools/importers/truelayer/importer.py
+++ b/src/tariochbctools/importers/truelayer/importer.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 from datetime import timedelta
 from os import path
 from typing import Any
@@ -35,6 +36,7 @@ class Importer(beangulp.Importer):
         self.clientId = None
         self.clientSecret = None
         self.refreshToken = None
+        self.authCommand = None
         self.sandbox = None
         self.existing = None
         self.domain = "truelayer.com"
@@ -42,10 +44,26 @@ class Importer(beangulp.Importer):
     def _configure(self, filepath: str, existing: data.Entries) -> None:
         with open(filepath, "r") as f:
             self.config = yaml.safe_load(f)
-        self.clientId = self.config["client_id"]
-        self.clientSecret = self.config["client_secret"]
-        self.refreshToken = self.config["refresh_token"]
-        self.sandbox = self.clientId.startswith("sandbox")
+
+        self.authCommand = self.config.get("auth_command")
+        self.accessToken = self.config.get("access_token")
+
+        # client_id/secret and refresh_token only required if no auth_command
+        if not self.authCommand:
+            self.clientId = self.config["client_id"]
+            self.clientSecret = self.config["client_secret"]
+            # refresh_token required if no access_token either
+            if not self.accessToken:
+                self.refreshToken = self.config["refresh_token"]
+            else:
+                self.refreshToken = self.config.get("refresh_token")
+        else:
+            # Optional: allow client_id for sandbox detection
+            self.clientId = self.config.get("client_id")
+            self.clientSecret = self.config.get("client_secret")
+            self.refreshToken = self.config.get("refresh_token")
+
+        self.sandbox = self.clientId and self.clientId.startswith("sandbox")
         self.existing = existing
 
         if self.sandbox:
@@ -60,21 +78,59 @@ class Importer(beangulp.Importer):
     def account(self, filepath: str) -> data.Account:
         return ""
 
+    def _get_access_token(self) -> str:
+        """return access token from cache, config or auth_command"""
+        if self.accessToken:
+            return self.accessToken
+
+        if self.authCommand:
+            logging.info("Running auth_command: %s", self.authCommand)
+            result = subprocess.run(
+                self.authCommand,
+                shell=True,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                stdout = result.stdout.strip()
+                error_parts = [
+                    f"auth_command failed with exit code {result.returncode}"
+                ]
+                if stderr:
+                    error_parts.append(f"stderr: {stderr}")
+                if stdout:
+                    error_parts.append(f"stdout: {stdout}")
+                if "oama" in self.authCommand:
+                    error_parts.append(
+                        "If using oama, you may need to re-authorize: "
+                        "oama authorize truelayer <your-account>"
+                    )
+                raise RuntimeError("; ".join(error_parts))
+            token = result.stdout.strip()
+            if not token:
+                raise RuntimeError("auth_command produced no output")
+            self.accessToken = token
+        else:
+            r = requests.post(
+                f"https://auth.{self.domain}/connect/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": self.clientId,
+                    "client_secret": self.clientSecret,
+                    "refresh_token": self.refreshToken,
+                },
+            )
+            tokens = r.json()
+            self.accessToken = tokens["access_token"]
+
+        return self.accessToken
+
     def extract(self, filepath: str, existing: data.Entries = None) -> data.Entries:
         self._configure(filepath, existing)
 
-        r = requests.post(
-            f"https://auth.{self.domain}/connect/token",
-            data={
-                "grant_type": "refresh_token",
-                "client_id": self.clientId,
-                "client_secret": self.clientSecret,
-                "refresh_token": self.refreshToken,
-            },
-        )
-        tokens = r.json()
-        accessToken = tokens["access_token"]
-        headers = {"Authorization": "Bearer " + accessToken}
+        access_token = self._get_access_token()
+        headers = {"Authorization": "Bearer " + access_token}
 
         entries = []
         entries.extend(self._extract_endpoint_transactions("accounts", headers))

--- a/tests/tariochbctools/importers/test_truelayer.py
+++ b/tests/tariochbctools/importers/test_truelayer.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 import dateutil.parser
 import pytest
@@ -238,3 +239,139 @@ def test_accounts_config_is_optional(importer_factory):
 
     importer = importer_factory(TEST_CONFIG_WITHOUT_ACCOUNTS)
     assert importer._get_account_for_account_id("any-account-id-1") == "DefaultAccount"
+
+
+def test_get_access_token_from_config(importer):
+    """Test that access_token from config is used when available."""
+    assert (
+        importer._get_access_token()
+        == "eyJhbGciOiJSUzI1NiIsImtpZsomethingSomethingsomethingDarkSideOEJBNk"
+    )
+
+
+def test_get_access_token_from_auth_command(importer_factory):
+    """Test that auth_command is used to get access token when no access_token in config."""
+    TEST_CONFIG_WITH_AUTH_COMMAND = b"""
+        account: DefaultAccount
+        client_id: sandbox-random
+        client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
+        refresh_token: 98D124C0E677865CB2F7D9DE91DC394CEED31DA3469C681B41FB7831F2F9B089
+        auth_command: "oama access natwest"
+    """
+
+    importer = importer_factory(TEST_CONFIG_WITH_AUTH_COMMAND)
+
+    with patch("subprocess.run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "new-access-token-from-oama\n"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        token = importer._get_access_token()
+
+        assert token == "new-access-token-from-oama"
+        mock_run.assert_called_once_with(
+            "oama access natwest",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def test_get_access_token_auth_command_failure(importer_factory):
+    """Test that auth_command failure raises RuntimeError."""
+    TEST_CONFIG_WITH_AUTH_COMMAND = b"""
+        account: DefaultAccount
+        client_id: sandbox-random
+        client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
+        refresh_token: 98D124C0E677865CB2F7D9DE91DC394CEED31DA3469C681B41FB7831F2F9B089
+        auth_command: "oama access natwest"
+    """
+
+    importer = importer_factory(TEST_CONFIG_WITH_AUTH_COMMAND)
+
+    with patch("subprocess.run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "authorization failed"
+        mock_run.return_value = mock_result
+
+        with pytest.raises(RuntimeError, match="auth_command failed with exit code 1"):
+            importer._get_access_token()
+
+
+def test_get_access_token_auth_command_empty_output(importer_factory):
+    """Test that auth_command with empty output raises RuntimeError."""
+    TEST_CONFIG_WITH_AUTH_COMMAND = b"""
+        account: DefaultAccount
+        client_id: sandbox-random
+        client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
+        refresh_token: 98D124C0E677865CB2F7D9DE91DC394CEED31DA3469C681B41FB7831F2F9B089
+        auth_command: "oama access natwest"
+    """
+
+    importer = importer_factory(TEST_CONFIG_WITH_AUTH_COMMAND)
+
+    with patch("subprocess.run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        with pytest.raises(RuntimeError, match="auth_command produced no output"):
+            importer._get_access_token()
+
+
+def test_refresh_token_optional_with_auth_command(importer_factory):
+    """Test that refresh_token is not required when auth_command is provided."""
+    TEST_CONFIG_WITHOUT_REFRESH = b"""
+        account: DefaultAccount
+        client_id: sandbox-random
+        client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
+        auth_command: "oama access natwest"
+    """
+
+    importer = importer_factory(TEST_CONFIG_WITHOUT_REFRESH)
+    assert importer.refreshToken is None
+    assert importer.authCommand == "oama access natwest"
+
+
+def test_refresh_token_required_without_auth_command(importer_factory):
+    """Test that refresh_token is required when neither auth_command nor access_token provided."""
+    TEST_CONFIG_WITHOUT_REFRESH = b"""
+        account: DefaultAccount
+        client_id: sandbox-random
+        client_secret: deadc0de-dead-c0de-dead-c0dedeadc0de
+    """
+
+    with pytest.raises(KeyError, match="refresh_token"):
+        importer_factory(TEST_CONFIG_WITHOUT_REFRESH)
+
+
+def test_client_id_secret_optional_with_auth_command(importer_factory):
+    """Test that client_id and client_secret are not required when auth_command is provided."""
+    TEST_CONFIG_WITHOUT_CLIENT = b"""
+        account: DefaultAccount
+        auth_command: "oama access natwest"
+    """
+
+    importer = importer_factory(TEST_CONFIG_WITHOUT_CLIENT)
+    assert importer.clientId is None
+    assert importer.clientSecret is None
+    assert importer.authCommand == "oama access natwest"
+
+
+def test_client_id_optional_with_auth_command_for_sandbox(importer_factory):
+    """Test that client_id can be provided with auth_command for sandbox detection."""
+    TEST_CONFIG_WITH_CLIENT = b"""
+        account: DefaultAccount
+        client_id: sandbox-test
+        auth_command: "oama access natwest"
+    """
+
+    importer = importer_factory(TEST_CONFIG_WITH_CLIENT)
+    assert importer.clientId == "sandbox-test"
+    assert importer.sandbox is True


### PR DESCRIPTION
There are now **two mechanisms** for obtaining TrueLayer access tokens:

**1. Direct refresh token - `refresh_token`**  
Provide a TrueLayer refresh token directly in the config. The importer
will exchange it for an access token on each run.

``` yaml
client_id: <CLIENT ID>
client_secret: <CLIENT SECRET>
refresh_token: <REFRESH TOKEN>
```

**2. External token manager (recommended) - `auth_command`**  
Use a tool like [oama](https://github.com/pdobsan/oama) to handle OAuth
automatically. oama stores refresh tokens securely and refreshes access
tokens in the background.

``` yaml
auth_command: "oama access <your-account>"
```

When using `auth_command`, you can omit `refresh_token`, `client_id` and
`client_secret` from the config (they are stored in oama's config
instead).

The importer obtains an access token in this order of preference:

1.  `access_token` from the config file (static, not recommended for production)
2.  Running `auth_command` (shell command, should output token to stdout)
3.  Using `refresh_token` to obtain a new access token from TrueLayer

Example `~/.config/oama/config.yaml` for TrueLayer:

``` yaml
services:
  truelayer:
    client_id: <YOUR_CLIENT_ID>
    client_secret: <YOUR_CLIENT_SECRET>
    auth_endpoint: https://auth.truelayer.com/
    auth_http_method: GET
    token_endpoint: https://auth.truelayer.com/connect/token
    auth_scope: "info accounts balance cards transactions direct_debits standing_orders offline_access"
    redirect_uri: http://localhost:3000/callback
```

@tarioch: is oama something we might consider extending to other .yaml-configured importers?